### PR TITLE
ign -> gz Environment Variable Migration : gz-msgs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -13,6 +13,7 @@ release will remove the deprecated code.
    Use `gz/...` instead.
 3. Protobuf messages and packages will no longer use `ignition.msgs`, use `gz.msgs` instead
 4. `INSTALL_IGN_MSGS_GEN_EXECUTABLE` and `IGN_MSGS_GEN_EXECUTABLE` are deprecated and will be removed. Use `INSTALL_GZ_MSGS_GEN_EXECUTABLE` and `GZ_MSGS_GEN_EXECUTABLE` instead.
+5. `IGN_DESCRIPTOR_PATH` is deprecated and will be removed. Use `GZ_DESCRIPTOR_PATH` instead.
 
 ## Gazebo Msgs 8.1 to 8.2
 

--- a/include/gz/msgs/Factory.hh
+++ b/include/gz/msgs/Factory.hh
@@ -48,7 +48,7 @@ namespace gz
     /// \class Factory Factory.hh gz/msgs.hh
     /// \brief A factory that generates protobuf message based on a string type.
     /// This class  will also try to load all Protobuf descriptors specified
-    /// in the IGN_DESCRIPTOR_PATH environment variable on program start.
+    /// in the GZ_DESCRIPTOR_PATH environment variable on program start.
     class GZ_MSGS_VISIBLE Factory
     {
       /// \brief Register a message.

--- a/src/Factory.cc
+++ b/src/Factory.cc
@@ -81,14 +81,14 @@ class DynamicFactory
   public: DynamicFactory()
   {
     // Try to get the list of paths from an environment variable.
-    const char *ignDescPaths = std::getenv("GZ_DESCRIPTOR_PATH");
-    if (!ignDescPaths)
+    const char *descPaths = std::getenv("GZ_DESCRIPTOR_PATH");
+    if (!descPaths)
     {
       // TODO(CH3): Deprecated. Remove on tock.
       // Remember to still return !!
-      ignDescPaths = std::getenv("IGN_DESCRIPTOR_PATH");
+      descPaths = std::getenv("IGN_DESCRIPTOR_PATH");
 
-      if (!ignDescPaths)
+      if (!descPaths)
       {
         return;
       }
@@ -100,7 +100,7 @@ class DynamicFactory
     }
 
     // Load all the descriptors found in the paths set with GZ_DESCRIPTOR_PATH.
-    this->LoadDescriptors(ignDescPaths);
+    this->LoadDescriptors(descPaths);
   }
 
   //////////////////////////////////////////////////

--- a/src/Factory.cc
+++ b/src/Factory.cc
@@ -69,7 +69,7 @@ std::vector<std::string> split(const std::string &_orig, char _delim)
 /////////////////////////////////////////////////
 /// \brief A factory class to generate protobuf messages at runtime based on
 /// their message descriptors. The location of the .desc files is expected
-/// via the IGN_DESCRIPTOR_PATH environment variable. This environment
+/// via the GZ_DESCRIPTOR_PATH environment variable. This environment
 /// variable expects paths to directories containing .desc files.
 /// Any file without the .desc extension will be ignored.
 class DynamicFactory
@@ -77,15 +77,29 @@ class DynamicFactory
   //////////////////////////////////////////////////
   /// \brief Constructor.
   /// The constructor will try to load all descriptors specified in the
-  /// IGN_DESCRIPTOR_PATH environment variable.
+  /// GZ_DESCRIPTOR_PATH environment variable.
   public: DynamicFactory()
   {
     // Try to get the list of paths from an environment variable.
-    const char *ignDescPaths = std::getenv("IGN_DESCRIPTOR_PATH");
+    const char *ignDescPaths = std::getenv("GZ_DESCRIPTOR_PATH");
     if (!ignDescPaths)
-      return;
+    {
+      // TODO(CH3): Deprecated. Remove on tock.
+      // Remember to still return !!
+      ignDescPaths = std::getenv("IGN_DESCRIPTOR_PATH");
 
-    // Load all the descriptors found in the paths set with IGN_DESCRIPTOR_PATH.
+      if (!ignDescPaths)
+      {
+        return;
+      }
+      else
+      {
+        std::cerr << "IGN_DESCRIPTOR_PATH is deprecated and will be removed! "
+                  << "Use GZ_DESCRIPTOR_PATH instead!" << std::endl;
+      }
+    }
+
+    // Load all the descriptors found in the paths set with GZ_DESCRIPTOR_PATH.
     this->LoadDescriptors(ignDescPaths);
   }
 

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -62,7 +62,7 @@ TEST(FactoryTest, New)
   EXPECT_TRUE(msg.get() != nullptr);
 
   unsetenv("GZ_DESCRIPTOR_PATH");
-  unsetenv("IGN_DESCRIPTOR_PATH");
+  setenv("IGN_DESCRIPTOR_PATH", "TEST_PATH", 1);
 
   msg = msgs::Factory::New<msgs::Vector3d>("gz.msgs.Vector3d");
   EXPECT_NE(msg, nullptr);

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -60,15 +60,6 @@ TEST(FactoryTest, New)
 
   msg = msgs::Factory::New<msgs::Vector3d>(".gz.msgs.Vector3d");
   EXPECT_TRUE(msg.get() != nullptr);
-
-  unsetenv("GZ_DESCRIPTOR_PATH");
-  setenv("IGN_DESCRIPTOR_PATH", "TEST_PATH", 1);
-
-  msg = msgs::Factory::New<msgs::Vector3d>("gz.msgs.Vector3d");
-  EXPECT_NE(msg, nullptr);
-
-  msg = msgs::Factory::New<msgs::Vector3d>(".gz.msgs.Vector3d");
-  EXPECT_TRUE(msg.get() != nullptr);
 }
 
 /////////////////////////////////////////////////

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -60,6 +60,15 @@ TEST(FactoryTest, New)
 
   msg = msgs::Factory::New<msgs::Vector3d>(".gz.msgs.Vector3d");
   EXPECT_TRUE(msg.get() != nullptr);
+
+  unsetenv("GZ_DESCRIPTOR_PATH");
+  unsetenv("IGN_DESCRIPTOR_PATH");
+
+  msg = msgs::Factory::New<msgs::Vector3d>("gz.msgs.Vector3d");
+  EXPECT_NE(msg, nullptr);
+
+  msg = msgs::Factory::New<msgs::Vector3d>(".gz.msgs.Vector3d");
+  EXPECT_TRUE(msg.get() != nullptr);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
See: https://github.com/gazebo-tooling/release-tools/issues/734

The deprecation warning is emitted using `std::cout` because `common` isn't included anywhere in `msgs`