### PR TITLE
Add EntityPlugin_V msg

### DIFF
--- a/proto/ignition/msgs/entity_plugin_v.proto
+++ b/proto/ignition/msgs/entity_plugin_v.proto
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "EntityPluginVProtos";
+
+/// \ingroup ignition.msgs
+/// \interface EntityPlugin_V
+/// \brief An array of plugins for a entity.
+
+import "ignition/msgs/entity.proto";
+import "ignition/msgs/header.proto";
+import "ignition/msgs/plugin.proto";
+
+message EntityPlugin_V
+{
+  /// \brief Optional header data
+  Header header = 1;
+
+  /// \brief Entity the plugins belong to
+  Entity entity = 2;
+
+  /// \brief Plugin messages.
+  repeated Plugin plugins = 3;
+}


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary
Adds an EntityPlugin_V.proto msg to store plugins / systems for an Entity.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
