### PR TITLE
Add entity wrench message

### DIFF
--- a/proto/ignition/msgs/entity_wrench.proto
+++ b/proto/ignition/msgs/entity_wrench.proto
@@ -1,0 +1,42 @@
+
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "EntityWrenchProtos";
+
+/// \ingroup ignition.msgs
+/// \interface EntityWrench
+/// \brief A wrench to apply to an entity
+
+import "ignition/msgs/entity.proto";
+import "ignition/msgs/header.proto";
+import "ignition/msgs/wrench.proto";
+
+message EntityWrench
+{
+  /// \brief Optional header data
+  Header header = 1;
+
+  /// \brief Entity to apply the wrench to.
+  Entity entity = 2;
+
+  /// \brief Wrench to apply.
+  Wrench wrench = 3;
+}


### PR DESCRIPTION
# 🎉 New feature

* Alternative to https://github.com/gazebosim/gz-msgs/pull/200

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This message can be used to:

* Define a wrench to be applied to an entity (I'm opening a `gz-sim` PR that makes use of it)
* Describing the wrench that's applied to an entity. That's the use case for the message added in #200. The differences are:
    * This message doesn't have a `pos` field, because I think it's duplicate from `wrench.force_offset`.
    * This message doesn't have a `label` field. I have a feeling that information like which plugin is applying a force is better left to the header.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

TODO `gz-sim` PR

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
