### PR TITLE
Generator: Add missing std namespace to string arguments (#242)

### DIFF
--- a/include/ignition/msgs/Generator.hh
+++ b/include/ignition/msgs/Generator.hh
@@ -43,9 +43,9 @@ class Generator : public CodeGenerator
   /// \param[in] _generatorContext Output directory.
   /// \param[in] _error Unused string value
   public: virtual bool Generate(const FileDescriptor *_file,
-              const string &_parameter,
+              const std::string &_parameter,
               OutputDirectory *_generatorContext,
-              string *_error) const;
+              std::string *_error) const;
 
   // private: GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(Generator);
 };

--- a/src/Generator.cc
+++ b/src/Generator.cc
@@ -67,7 +67,7 @@ Generator::~Generator()
 
 /////////////////////////////////////////////////
 bool Generator::Generate(const FileDescriptor *_file,
-                               const string &/*_parameter*/,
+                               const std::string &/*_parameter*/,
                                OutputDirectory *_generatorContext,
                                std::string * /*_error*/) const
 {

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -22,4 +22,35 @@
 #define IGN_CONFIG_PATH "@CMAKE_BINARY_DIR@/test/conf"
 #define IGN_TEST_LIBRARY_PATH "${PROJECT_BINARY_DIR}/src"
 
+#if (_MSC_VER >= 1400) // Visual Studio 2005
+  #include <sstream>
+
+  /// \brief setenv/unstenv are not present in Windows. Define them to make
+  /// the code portable.
+  /// \param[in] _name Variable name.
+  /// \param[in] _value Value.
+  /// \param[in] _rewrite If 'name' does exist in the environment, then its
+  /// value is changed to 'value' if 'rewrite' is nonzero. If overwrite is
+  /// zero, then the value of 'name' is not changed.
+  /// /return 0 on success or -1 on error.
+  int setenv(const char *_name, const char *_value, int /*_rewrite*/)
+  {
+    std::stringstream sstr;
+    std::string name = _name;
+    std::string value = _value;
+    sstr << name << '=' << value;
+    return _putenv(sstr.str().c_str());
+  }
+
+  /// \brief Deletes an environment variable.
+  /// \param[in] _name Variable name.
+  void unsetenv(const char *_name)
+  {
+    std::stringstream sstr;
+    std::string name = _name;
+    sstr << name << '=';
+    _putenv(sstr.str().c_str());
+  }
+#endif
+
 #endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,10 +2,15 @@ include_directories(
   ${CMAKE_BINARY_DIR}
   ${CMAKE_BINARY_DIR}/test
 )
-
 set (test_sources
   ign_TEST.cc
 )
+
+# Skip command line tests for Windows, see
+# https://bitbucket.org/ignitionrobotics/ign-msgs/issues/28
+if (MSVC)
+  list(REMOVE_ITEM test_sources ign_TEST.cc)
+endif()
 
 if (IGNITION-TOOLS_BINARY_DIRS)
   ign_build_tests(TYPE UNIT SOURCES ${test_sources})

--- a/tools/ign_TEST.cc
+++ b/tools/ign_TEST.cc
@@ -20,6 +20,11 @@
 #include <ignition/msgs/config.hh>
 #include "ignition/msgs/test_config.h"
 
+#ifdef _MSC_VER
+#    define popen _popen
+#    define pclose _pclose
+#endif
+
 static const std::string g_version(std::string(IGNITION_MSGS_VERSION_FULL));
 
 /////////////////////////////////////////////////

--- a/tools/ign_TEST.cc
+++ b/tools/ign_TEST.cc
@@ -99,7 +99,6 @@ int main(int argc, char **argv)
 
   // Make sure that we load the library recently built and not the one installed
   // in your system.
-#ifndef _WIN32
   // Add the directory where ignition msgs has been built.
   std::string value = std::string(IGN_TEST_LIBRARY_PATH);
   // Save the current value of LD_LIBRARY_PATH.
@@ -107,7 +106,6 @@ int main(int argc, char **argv)
   if (cvalue)
     value += ":" + std::string(cvalue);
   setenv("LD_LIBRARY_PATH", value.c_str(), 1);
-#endif
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
# 🦟 Bug fix

Backport #242 to `ign-msgs1`

## Summary

Fix homebrew build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_msgs-ci-ign-msgs1-homebrew-amd64&build=33)](https://build.osrfoundation.org/job/ignition_msgs-ci-ign-msgs1-homebrew-amd64/33/) https://build.osrfoundation.org/job/ignition_msgs-ci-ign-msgs1-homebrew-amd64/33/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Use rebase and merge