### PR TITLE
[ign to gz] Factory::New accept ignition with warning

### DIFF
--- a/include/gz/msgs/Factory.hh
+++ b/include/gz/msgs/Factory.hh
@@ -64,8 +64,16 @@ namespace gz
       public: template<typename T>
               static std::unique_ptr<T> New(const std::string &_msgType)
               {
+                auto msgType = _msgType;
+                if (msgType.find("ignition") == 0)
+                {
+                  msgType.replace(0, 8, "gz");
+                  std::cerr << "Trying to create deprecated message type ["
+                            << _msgType << "]. Use [" << msgType << "] instead."
+                            << std::endl;
+                }
                 return std::unique_ptr<T>(
-                    static_cast<T*>(New(_msgType).release()));
+                    static_cast<T*>(New(msgType).release()));
               }
 
       /// \brief Create a new instance of a message.
@@ -77,8 +85,16 @@ namespace gz
               static std::unique_ptr<T> New(const std::string &_msgType,
                   const std::string &_args)
               {
+                auto msgType = _msgType;
+                if (msgType.find("ignition") == 0)
+                {
+                  msgType.replace(0, 8, "gz");
+                  std::cerr << "Trying to create deprecated message type ["
+                            << _msgType << "]. Use [" << msgType << "] instead."
+                            << std::endl;
+                }
                 return std::unique_ptr<T>(
-                    static_cast<T*>(New(_msgType, _args).release()));
+                    static_cast<T*>(New(msgType, _args).release()));
               }
 
       /// \brief Create a new instance of a message.

--- a/src/Factory.cc
+++ b/src/Factory.cc
@@ -161,16 +161,25 @@ class DynamicFactory
   /// type could not be handled.
   public: static ProtoUniquePtr New(const std::string &_msgType)
   {
+    auto msgType = _msgType;
+    if (msgType.find("ignition") == 0)
+    {
+      msgType.replace(0, 8, "gz");
+      std::cerr << "Trying to create deprecated message type ["
+                << _msgType << "]. Use [" << msgType << "] instead."
+                << std::endl;
+    }
+
     // Shortcut if the type has been already registered.
     std::map<std::string, std::function<ProtoUniquePtr()>>::iterator msgF =
-      dynamicMsgMap.find(_msgType);
+      dynamicMsgMap.find(msgType);
 
     if (msgF != dynamicMsgMap.end())
       return msgF->second();
 
     // Nothing to do if we don't know about this type in the descriptor map.
     const google::protobuf::Descriptor *descriptor =
-      pool.FindMessageTypeByName(_msgType);
+      pool.FindMessageTypeByName(msgType);
     if (!descriptor)
       return nullptr;
 
@@ -227,25 +236,34 @@ void Factory::Register(const std::string &_msgType,
 std::unique_ptr<google::protobuf::Message> Factory::New(
     const std::string &_msgType)
 {
+  auto msgType = _msgType;
+  if (msgType.find("ignition") == 0)
+  {
+    msgType.replace(0, 8, "gz");
+    std::cerr << "Trying to create deprecated message type ["
+              << _msgType << "]. Use [" << msgType << "] instead."
+              << std::endl;
+  }
+
   std::unique_ptr<google::protobuf::Message> msg;
 
   std::string type;
   // Convert "gz.msgs." to "gz_msgs.".
-  if (_msgType.find("gz.msgs.") == 0)
+  if (msgType.find("gz.msgs.") == 0)
   {
-    type = "gz_msgs." + _msgType.substr(8);
+    type = "gz_msgs." + msgType.substr(8);
   }
   // Convert ".gz.msgs." to "gz_msgs.".
-  else if (_msgType.find(".gz.msgs.") == 0)
+  else if (msgType.find(".gz.msgs.") == 0)
   {
-    type = "gz_msgs." + _msgType.substr(9);
+    type = "gz_msgs." + msgType.substr(9);
   }
   else
   {
     // Fix typenames that are missing "gz_msgs." at the beginning.
-    if (_msgType.find("gz_msgs.") != 0)
+    if (msgType.find("gz_msgs.") != 0)
       type = "gz_msgs.";
-    type += _msgType;
+    type += msgType;
   }
 
   // Create a new message if a FactoryFn has been assigned to the message type
@@ -253,7 +271,7 @@ std::unique_ptr<google::protobuf::Message> Factory::New(
     return ((*msgMap)[type]) ();
 
   // Check if we have the message descriptor.
-  msg = dynamicFactory.New(_msgType);
+  msg = dynamicFactory.New(msgType);
 
   return msg;
 }
@@ -262,7 +280,16 @@ std::unique_ptr<google::protobuf::Message> Factory::New(
 std::unique_ptr<google::protobuf::Message> Factory::New(
     const std::string &_msgType, const std::string &_args)
 {
-  std::unique_ptr<google::protobuf::Message> msg = New(_msgType);
+  auto msgType = _msgType;
+  if (msgType.find("ignition") == 0)
+  {
+    msgType.replace(0, 8, "gz");
+    std::cerr << "Trying to create deprecated message type ["
+              << _msgType << "]. Use [" << msgType << "] instead."
+              << std::endl;
+  }
+
+  std::unique_ptr<google::protobuf::Message> msg = New(msgType);
   if (msg)
   {
     google::protobuf::TextFormat::ParseFromString(_args, msg.get());


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/711
* Closes https://github.com/gazebosim/gz-transport/issues/331

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Accept `ignition` messages on `Factory::New`, print warning and return `gz` equivalent.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Try sending an `ignition` message, see that it's sent, and a warning is printed.

```
ign topic -t /model/joint/thruster4_joint/cmd_thrust -m ignition.msgs.Double -p 'data: 5'
Trying to create deprecated message type [ignition.msgs.Double]. Use [gz.msgs.Double] instead.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
