### PR TITLE
Increase Utility coverage

### DIFF
--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -780,10 +780,12 @@ namespace ignition
             case msgs::PointCloudPacked::Field::FLOAT64:
               offset += 8;
               break;
+            // LCOV_EXCL_START
             default:
               std::cerr << "PointCloudPacked field datatype of ["
                 << _type << "] is invalid.\n";
               break;
+            // LCOV_EXCL_STOP
           }
         };
 
@@ -1005,6 +1007,14 @@ namespace ignition
       }
       meta.set_name(trimmed(elem->GetText()));
 
+      // Read the version, if present.
+      elem = modelElement->FirstChildElement("version");
+      if (elem && elem->GetText())
+      {
+        auto version = std::stoi(trimmed(elem->GetText()));
+        meta.set_version(version);
+      }
+
       // Read the description, if present.
       elem = modelElement->FirstChildElement("description");
       if (elem && elem->GetText())
@@ -1101,7 +1111,11 @@ namespace ignition
         }
 
         out << "<?xml version='1.0'?>\n"
-            << "  <model>\n";
+            << "  <model>\n"
+            << "    <sdf version='"
+            << _meta.model().file_format().version().major()
+            << "." << _meta.model().file_format().version().minor() << "'>"
+            << _meta.model().file() << "</sdf>\n";
       }
       else
       {
@@ -1112,15 +1126,16 @@ namespace ignition
         }
 
         out << "<?xml version='1.0'?>\n"
-            << "  <world>\n";
+            << "  <world>\n"
+            << "    <sdf version='"
+            << _meta.world().file_format().version().major()
+            << "." << _meta.world().file_format().version().minor() << "'>"
+            << _meta.world().file() << "</sdf>\n";
       }
 
       out << "    <name>" << _meta.name() << "</name>\n"
-        << "    <version>" << _meta.version() << "</version>\n"
-        << "    <sdf version='" << _meta.model().file_format().version().major()
-        << "." << _meta.model().file_format().version().minor() << "'>"
-        << _meta.model().file() << "</sdf>\n"
-        << "    <description>" << _meta.description() << "</description>\n";
+          << "    <version>" << _meta.version() << "</version>\n"
+          << "    <description>" << _meta.description() << "</description>\n";
 
       // Output author information.
       for (int i = 0; i < _meta.authors_size(); ++i)
@@ -1135,9 +1150,9 @@ namespace ignition
       for (int i = 0; i < _meta.dependencies_size(); ++i)
       {
         out << "    <depend>\n"
-        << "      <model>"
+        << "      <model>\n"
         << "        <uri>" << _meta.dependencies(i).uri() << "</uri>\n"
-        << "      </model>"
+        << "      </model>\n"
         << "    </depend>\n";
       }
 

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -52,31 +52,6 @@ namespace ignition
       return _s;
     }
 
-    /// \brief Splits a string into tokens. This was copied from ignition
-    /// common, ign-common/Util.hh, to avoid adding another dependency.
-    /// Remove this function if ign-common every becomes a dependency.
-    /// \param[in] _str Input string.
-    /// \param[in] _delim Token delimiter.
-    /// \return Vector of tokens.
-    std::vector<std::string> split(const std::string &_str,
-        const std::string &_delim)
-    {
-      std::vector<std::string> tokens;
-      char *saveptr;
-      char *str = strdup(_str.c_str());
-
-      auto token = ignstrtok(str, _delim.c_str(), &saveptr);
-
-      while (token)
-      {
-        tokens.push_back(token);
-        token = ignstrtok(NULL, _delim.c_str(), &saveptr);
-      }
-
-      free(str);
-      return tokens;
-    }
-
     /////////////////////////////////////////////
     ignition::math::Vector3d Convert(const msgs::Vector3d &_v)
     {

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -964,14 +964,14 @@ namespace ignition
         return false;
       }
 
-      // Get the top level <model> element.
-      tinyxml2::XMLElement *modelElement = modelConfigDoc.FirstChildElement(
+      // Get the top level <model> or <world> element.
+      tinyxml2::XMLElement *topElement = modelConfigDoc.FirstChildElement(
           "model");
       bool isModel = true;
-      if (!modelElement)
+      if (!topElement)
       {
-        modelElement = modelConfigDoc.FirstChildElement("world");
-        if (!modelElement)
+        topElement = modelConfigDoc.FirstChildElement("world");
+        if (!topElement)
         {
           std::cerr << "Model config string does not contain a "
                     << "<model> or <world> element\n";
@@ -981,7 +981,7 @@ namespace ignition
       }
 
       // Read the name, which is a mandatory element.
-      tinyxml2::XMLElement *elem = modelElement->FirstChildElement("name");
+      tinyxml2::XMLElement *elem = topElement->FirstChildElement("name");
       if (!elem || !elem->GetText())
       {
         std::cerr << "Model config string does not contain a <name> element\n";
@@ -990,7 +990,7 @@ namespace ignition
       meta.set_name(trimmed(elem->GetText()));
 
       // Read the version, if present.
-      elem = modelElement->FirstChildElement("version");
+      elem = topElement->FirstChildElement("version");
       if (elem && elem->GetText())
       {
         auto version = std::stoi(trimmed(elem->GetText()));
@@ -998,12 +998,12 @@ namespace ignition
       }
 
       // Read the description, if present.
-      elem = modelElement->FirstChildElement("description");
+      elem = topElement->FirstChildElement("description");
       if (elem && elem->GetText())
         meta.set_description(trimmed(elem->GetText()));
 
       // Read the dependencies, if any.
-      elem = modelElement->FirstChildElement("depend");
+      elem = topElement->FirstChildElement("depend");
       while (elem)
       {
         auto modelElem = elem->FirstChildElement("model");
@@ -1020,7 +1020,7 @@ namespace ignition
       }
 
       // Read the authors, if any.
-      elem = modelElement->FirstChildElement("author");
+      elem = topElement->FirstChildElement("author");
       while (elem)
       {
         ignition::msgs::FuelMetadata::Contact *author = meta.add_authors();
@@ -1041,7 +1041,7 @@ namespace ignition
       }
 
       // Get the most recent SDF file
-      elem = modelElement->FirstChildElement("sdf");
+      elem = topElement->FirstChildElement("sdf");
       math::SemanticVersion maxVer;
       while (elem)
       {


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-sim/issues/1575

## Summary
- Increased `Utility.cc` coverage by adding tests for `ConvertFuelMetadata` methods
- Updated `ConvertFuelMetadata(string, msgs::FuelMetadata)` function to take care of `<world>`: a1d294d585853553e5d89e32c61d3716950f73f2 (commit message is backwards :sweat_smile:)
- Removed unused `split` function: 8ff8356a98ba47c1206e466f074e68e46e059110

## Test it
```bash
./path/to/build/UNIT_Utility_TEST --gtest_filter="*ConvertFuelMetadata"
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.