### PR TITLE
Safer move/rename for Windows

### DIFF
--- a/tools/gz_msgs_generate.py
+++ b/tools/gz_msgs_generate.py
@@ -87,11 +87,17 @@ def main(argv=sys.argv[1:]):
     gz_header = os.path.join(args.output_cpp_path, proto_file + ".gz.h")
     detail_header = os.path.join(args.output_cpp_path, detail_proto_file + ".pb.h")
 
-    os.makedirs(os.path.join(args.output_cpp_path, detail_proto_dir),
-            exist_ok=True)
-
-    os.rename(header, detail_header)
-    os.rename(gz_header, header)
+    try:
+        os.makedirs(os.path.join(args.output_cpp_path, detail_proto_dir),
+                exist_ok=True)
+        # Windows cannot rename a file to an existing file
+        if os.path.exists(detail_header):
+            os.remove(detail_header)
+        os.rename(header, detail_header)
+        os.rename(gz_header, header)
+    except e:
+        print(f'Failed to manipulate gz-msgs headers: {e}')
+        sys.exit(-1)
 
     ignition_header_dir = os.path.join(args.output_cpp_path, 'ignition', 'msgs')
     ignition_header = proto_file.split(os.sep)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fix an issue where multiple builds of the same workspace on Windows can end in error.  Windows won't allow you to rename a file over a file that is already existing.  As an adjustment, this checks for previous built output and removes it.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.