### PR TITLE
ParemeterError: rename NO_ERROR to SUCCESS

### DIFF
--- a/proto/ignition/msgs/parameter_error.proto
+++ b/proto/ignition/msgs/parameter_error.proto
@@ -27,7 +27,7 @@ option java_outer_classname = "ParameterErrorProtos";
 message ParameterError
 {
   enum Type {
-    NO_ERROR = 0;
+    SUCCESS = 0;
     ALREADY_DECLARED = 1;
     INVALID_TYPE = 2;
     NOT_DECLARED = 3;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-transport/pull/305#issuecomment-1221045181.

## Summary

To avoid conflicts with `winerror.h` macro.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
