### PR TITLE
Fix cross-compilation workflow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,7 @@ function(gz_msgs_protoc)
     COMMAND Python3::Interpreter
     ARGS tools/gz_msgs_generate.py
       --protoc-exec "$<TARGET_FILE:${gz_msgs_protoc_PROTOC_EXEC}>"
-      --gz-generator-bin "$<TARGET_FILE:gz_msgs_gen>"
+      --gz-generator-bin "${GZ_MSGS_GEN_EXECUTABLE}"
       --generate-cpp "${gz_msgs_protoc_GENERATE_CPP}"
       --generate-ruby "${gz_msgs_protoc_GENERATE_RUBY}"
       --generate-ignition "TRUE"


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the failure we experienced in https://github.com/conda-forge/gz-msgs-feedstock/pull/3 .

## Summary

The cross-compilation workflow originally added in https://github.com/gazebosim/gz-msgs/pull/60 and documented in https://github.com/gazebosim/gz-msgs/blob/2356549c8cf3667d8a326f9c7ecb791c43ba02df/CMakeLists.txt#L32 did not work after in  https://github.com/gazebosim/gz-msgs/pull/256 the use of `${GZ_MSGS_GEN_EXECUTABLE}` was changed back to directly use `$<TARGET_FILE:gz_msgs_gen>`.

This PR restores the cross-compilation workflow, and it has been tested successfully in https://github.com/conda-forge/gz-msgs-feedstock/pull/3 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
