### PR TITLE
Add entity wrench vector message

### DIFF
--- a/proto/gz/msgs/entity_wrench_v.proto
+++ b/proto/gz/msgs/entity_wrench_v.proto
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package gz.msgs;
+option java_package = "com.gz.msgs";
+option java_outer_classname = "EntityWrenchVProtos";
+
+/// \ingroup gz.msgs
+/// \interface EntityWrench_V
+/// \brief A message for a vector of EntityWrench messages
+
+import "gz/msgs/entity_wrench.proto";
+import "gz/msgs/header.proto";
+
+message EntityWrench_V
+{
+  /// \brief Optional header data
+  Header header = 1;
+
+  /// \brief The vector of EntityWrench messages
+  repeated EntityWrench data = 2;
+}


### PR DESCRIPTION
# 🎉 New feature

Supersedes #200

## Summary

Add the vector version of the existing `entity_wrench` message. Required for downstream `gz-sim` force visualization PR https://github.com/gazebosim/gz-sim/pull/1898.

## Test it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.