### PR TITLE
Add id and visibility_flags to Projector msg fields

### DIFF
--- a/proto/gz/msgs/projector.proto
+++ b/proto/gz/msgs/projector.proto
@@ -21,7 +21,7 @@ option java_package = "com.gz.msgs";
 option java_outer_classname = "ProjectorProtos";
 
 /// \ingroup gz.msgs
-/// \interface Projector 
+/// \interface Projector
 /// \brief Information about a projector
 
 import "gz/msgs/pose.proto";
@@ -39,4 +39,12 @@ message Projector
   double near_clip     = 6;
   double far_clip      = 7;
   bool enabled         = 8;
+
+  /// \brief Unique ID associated with the projector
+  uint32 id            = 9;
+
+  /// \brief Visibility flags of a projector. When a camera's visibility_mask
+  /// & (bitwise AND) the projector's visibility_flags evaluates to non-zero,
+  /// the projected pattern will be visible to the camera.
+  uint32 visibility_flags = 10;
 }


### PR DESCRIPTION


# 🎉 New feature

Closes https://github.com/gazebosim/gz-msgs/issues/341

## Summary
Adding a couple of fields to projector msg
* `id`: Unique entity id
* `visibility_flags`: If the projector's visibility flags matches a camera's visibility_mask, then the projector will be visible to the camera. 

Related todo note in gz-sim: https://github.com/gazebosim/gz-sim/blob/gz-sim7/src/Conversions.cc#L1790

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
