### PR TITLE
Cherry-pick #346 to garden: GzProtobuf: Do not require version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-set(REQ_PROTOBUF_VER 3)
 gz_find_package(GzProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  COMPONENTS all
                  PRETTY Protobuf)


### PR DESCRIPTION
Cherry-pick of #346 to Garden. Use rebase-and-merge.

Thanks to @traversaro for the patch!