### PR TITLE
Add python message generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ add_subdirectory(tools)
 # projects.
 add_subdirectory(proto)
 
+# Generate python
+add_subdirectory(python)
+
 #============================================================================
 # Create package information
 #============================================================================

--- a/cmake/gz_msgs_protoc.cmake
+++ b/cmake/gz_msgs_protoc.cmake
@@ -2,6 +2,7 @@
 # A function that calls protoc on a protobuf file
 # Options:
 #   GENERATE_CPP        - generates c++ code for the message if specified
+#   GENERATE_PYTHON       - generates python code for the message if specified
 # One value arguments:
 #   MSGS_GEN_SCRIPT     - Path to the message generation python script
 #   PROTO_PACKAGE       - Protobuf package the file belongs to (e.g. "gz.msgs")
@@ -9,15 +10,17 @@
 #   GZ_PROTOC_PLUGIN    - Path to the gazebo-specific protobuf compiler executable
 #   INPUT_PROTO         - Path to the input .proto file
 #   OUTPUT_CPP_DIR      - Path where C++ files are saved
+#   OUTPUT_PYTHON_DIR     - Path where Python files are saved
 #   OUTPUT_INCLUDES     - A CMake variable name containing a list that the C++ header path should be appended to
 #   OUTPUT_CPP_HH_VAR   - A CMake variable name containing a list generated headers should be appended to
 #   OUTPUT_DETAIL_CPP_HH_VAR - A CMake variable name containing a list that the C++ detail headers should be appended to
 #   OUTPUT_CPP_CC_VAR   - A Cmake variable name containing a list that the C++ source files should be appended to
+#   OUTPUT_PYTHON_VAR     - A Cmake variable name containing a list that the python file should be appended to
 # Multi value arguments
 #   PROTO_PATH          - Passed to protoc --proto_path
 #   DEPENDENCY_PROTO_PATHS - Passed to protoc --proto_path
 function(gz_msgs_protoc)
-  set(options GENERATE_CPP)
+  set(options GENERATE_CPP GENERATE_PYTHON)
   set(oneValueArgs
     MSGS_GEN_SCRIPT
     PROTO_PACKAGE
@@ -25,10 +28,12 @@ function(gz_msgs_protoc)
     GZ_PROTOC_PLUGIN
     INPUT_PROTO
     OUTPUT_CPP_DIR
+    OUTPUT_PYTHON_DIR
     OUTPUT_INCLUDES
     OUTPUT_CPP_HH_VAR
     OUTPUT_DETAIL_CPP_HH_VAR
-    OUTPUT_CPP_CC_VAR)
+    OUTPUT_CPP_CC_VAR
+    OUTPUT_PYTHON_VAR)
   set(multiValueArgs PROTO_PATH DEPENDENCY_PROTO_PATHS)
 
   cmake_parse_arguments(gz_msgs_protoc "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -40,6 +45,9 @@ function(gz_msgs_protoc)
   set(output_files)
 
   _gz_msgs_proto_pkg_to_path(${gz_msgs_protoc_PROTO_PACKAGE} proto_package_dir)
+
+  # Variable to hold which language is being generated. It'll be used in the comment of add_custom_command below
+  set(output_language)
 
   if(gz_msgs_protoc_GENERATE_CPP)
     # Full path to gazeob-specific header (${PROJECT_BINARY_DIR}/include/gz/msgs/foo.pb.h)
@@ -71,11 +79,23 @@ function(gz_msgs_protoc)
     set(${gz_msgs_protoc_OUTPUT_DETAIL_CPP_HH_VAR} ${${gz_msgs_protoc_OUTPUT_DETAIL_CPP_HH_VAR}} PARENT_SCOPE)
     set(${gz_msgs_protoc_OUTPUT_CPP_HH_VAR} ${${gz_msgs_protoc_OUTPUT_CPP_HH_VAR}} PARENT_SCOPE)
     set(${gz_msgs_protoc_OUTPUT_CPP_CC_VAR} ${${gz_msgs_protoc_OUTPUT_CPP_CC_VAR}} PARENT_SCOPE)
+
+    set(output_language "(C++)")
   endif()
+
+  if(gz_msgs_protoc_GENERATE_PYTHON)
+    file(MAKE_DIRECTORY ${gz_msgs_protoc_OUTPUT_PYTHON_DIR})
+    # Note: Both proto2 and proto3 use the _pb2.py suffix (https://protobuf.dev/reference/python/python-generated/#invocation)
+    set(output_python "${gz_msgs_protoc_OUTPUT_PYTHON_DIR}/${proto_package_dir}/${FIL_WE}_pb2.py")
+    list(APPEND ${gz_msgs_protoc_OUTPUT_PYTHON_VAR} ${output_python})
+    list(APPEND output_files ${output_python})
+    set(${gz_msgs_protoc_OUTPUT_PYTHON_VAR} ${${gz_msgs_protoc_OUTPUT_PYTHON_VAR}} PARENT_SCOPE)
+    set(output_language "(Python)")
+  endif()
+
 
   set(GENERATE_ARGS
       --protoc-exec "$<TARGET_FILE:${gz_msgs_protoc_PROTOC_EXEC}>"
-      --gz-generator-bin "${gz_msgs_protoc_GZ_PROTOC_PLUGIN}"
       --proto-path "${gz_msgs_protoc_PROTO_PATH}"
       --input-path "${ABS_FIL}"
   )
@@ -89,7 +109,14 @@ function(gz_msgs_protoc)
   if(${gz_msgs_protoc_GENERATE_CPP})
     list(APPEND GENERATE_ARGS
       --generate-cpp
+      --gz-generator-bin "${gz_msgs_protoc_GZ_PROTOC_PLUGIN}"
       --output-cpp-path "${gz_msgs_protoc_OUTPUT_CPP_DIR}")
+  endif()
+
+  if(${gz_msgs_protoc_GENERATE_PYTHON})
+    list(APPEND GENERATE_ARGS
+      --generate-python
+      --output-python-path "${gz_msgs_protoc_OUTPUT_PYTHON_DIR}")
   endif()
 
   add_custom_command(
@@ -101,7 +128,7 @@ function(gz_msgs_protoc)
     # While the script is executed in the source directory, it does not write
     # to the source tree.  All outputs are stored in the build directory.
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    COMMENT "Running protoc on ${gz_msgs_protoc_INPUT_PROTO}"
+    COMMENT "Running protoc ${output_language} on ${gz_msgs_protoc_INPUT_PROTO}"
     VERBATIM
   )
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,39 @@
+include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_string_utils.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_factory.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_generate.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_protoc.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/target_link_messages.cmake)
+
+file (GLOB proto_files ${PROJECT_SOURCE_DIR}/proto/gz/msgs/*.proto)
+
+foreach(proto_file ${proto_files})
+  gz_msgs_protoc(
+    MSGS_GEN_SCRIPT
+      ${PROJECT_SOURCE_DIR}/tools/gz_msgs_generate.py
+    PROTO_PACKAGE
+      "gz.msgs"
+    GENERATE_PYTHON
+    INPUT_PROTO
+      ${proto_file}
+    PROTOC_EXEC
+      protobuf::protoc
+    OUTPUT_PYTHON_DIR
+      "${PROJECT_BINARY_DIR}/python"
+    OUTPUT_PYTHON_VAR
+      gen_python_scripts
+    PROTO_PATH
+      "${PROJECT_SOURCE_DIR}/proto")
+endforeach()
+
+set_source_files_properties(
+  ${gen_python_scripts}
+  PROPERTIES GENERATED TRUE)
+
+add_custom_target(gz_msgs_python ALL DEPENDS ${gen_python_scripts})
+
+message(STATUS "Installing Python messages to ${CMAKE_INSTALL_PREFIX}/${GZ_LIB_INSTALL_DIR}/python/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
+set(python_init_file ${PROJECT_BINARY_DIR}/python/gz/${GS_DESIGNATION}/__init__.py)
+configure_file(${PROJECT_SOURCE_DIR}/python/src/__init__.py.in ${python_init_file})
+list(APPEND gen_python_scripts "${python_init_file}")
+
+install(FILES ${gen_python_scripts} DESTINATION ${CMAKE_INSTALL_PREFIX}/${GZ_LIB_INSTALL_DIR}/python/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR})

--- a/python/src/__init__.py.in
+++ b/python/src/__init__.py.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is a workaround for a limitation in out protobuf python generation
+# where a message that depends on another message will try to import the
+# corresponding python module using `gz.msgs` as the package name. However,
+# we're installing the python modules in a directory that contains the gz-msgs
+# major version number, so the import fails. This hack here overwrites the
+# entry for the unversioned module name in `sys.modules` to point to the
+# versioned module the first time a message module is loaded. Subsequent
+# imports with or without the major version number will work properly.
+
+import sys
+unversioned_module = 'gz.msgs'
+versioned_module = "{}{}".format(unversioned_module, @PROJECT_VERSION_MAJOR@)
+if unversioned_module in sys.modules:
+    print("Looks like you are combining different versions of {}. Found {} and"
+          "{} This is not supported".format(sys.modules[unversioned_module],
+                                            sys.modules[versioned_module]))
+else:
+    sys.modules[unversioned_module] = sys.modules[versioned_module]


### PR DESCRIPTION
# 🎉 New feature

## Summary
Uses the new message generation framework to generate protobuf python files. This will be used by https://github.com/gazebosim/gz-transport/pull/411. Since we won't be concerned with ABI issues for python files, I think it would be okay to provide binary distributions for the generated files.



## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


