### PR TITLE
Unconditionally find the python interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 gz_find_package(gz-math7 REQUIRED)
 set(GZ_MATH_VER ${gz-math7_VERSION_MAJOR})
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 #--------------------------------------
 # Find if command is available. This is used to enable tests.
 # Note that CLI files are installed regardless of whether the dependency is


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #354 

## Summary

The python interpreter was only being found with BUILD_TESTING enabled.  This makes it an unconditional dependency.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
