### PR TITLE
Use computed relative extras path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ gz_configure_project(VERSION_SUFFIX
 # Install cmake support files
 install(
   DIRECTORY cmake/
-  DESTINATION "lib/cmake/${PROJECT_NAME}"
+  DESTINATION "${PROJECT_CMAKE_EXTRAS_INSTALL_DIR}"
 )
 
 #============================================================================

--- a/gz-msgs-extras.cmake.in
+++ b/gz-msgs-extras.cmake.in
@@ -22,7 +22,7 @@ include(${@PROJECT_NAME@_DIR}/gz_msgs_factory.cmake)
 include(${@PROJECT_NAME@_DIR}/gz_msgs_generate.cmake)
 include(${@PROJECT_NAME@_DIR}/target_link_messages.cmake)
 
-set(@PROJECT_NAME@_INSTALL_PATH "${@PROJECT_NAME@_DIR}/../../..")
+set(@PROJECT_NAME@_INSTALL_PATH "${@PROJECT_NAME@_DIR}/@PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX@")
 cmake_path(NORMAL_PATH @PROJECT_NAME@_INSTALL_PATH OUTPUT_VARIABLE @PROJECT_NAME@_INSTALL_PATH)
 set(PROTOC_NAME "@PROJECT_NAME@_protoc_plugin")
 set(PROTO_SCRIPT_NAME "@PROJECT_NAME@_generate.py")
@@ -40,7 +40,7 @@ function(gz_msgs_get_installed_messages)
 
   cmake_parse_arguments(get_installed_messages "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  set(@PROJECT_NAME@_INSTALL_PATH "${@PROJECT_NAME@_DIR}/../../..")
+  set(@PROJECT_NAME@_INSTALL_PATH "${@PROJECT_NAME@_DIR}/@PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX@")
   cmake_path(NORMAL_PATH @PROJECT_NAME@_INSTALL_PATH OUTPUT_VARIABLE @PROJECT_NAME@_INSTALL_PATH)
 
   set(@PROJECT_NAME@_PROTO_PATH ${@PROJECT_NAME@_INSTALL_PATH}/share/protos)


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/gazebosim/gz-transport/pull/398, follow-up to https://github.com/gazebosim/gz-cmake/pull/360 and https://github.com/gazebosim/gz-msgs/pull/339#discussion_r1247319505

## Summary

Use `PROJECT_CMAKE_EXTRAS_INSTALL_DIR` and `PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX` to improve support for arch-dependent lib folders. In particular, the fixed relative path `../../..` is incorrect when installing to `/usr` on debian systems, so the computed relative path `PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX` is used instead. Also install the other cmake extras to `PROJECT_CMAKE_EXTRAS_INSTALL_DIR`.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
