### PR TITLE
Use CMake's protobuf module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-gz_find_package(GzProtobuf
-                 REQUIRED
-                 COMPONENTS all
-                 PRETTY Protobuf)
+find_package(Protobuf MODULE REQUIRED)
 
 #--------------------------------------
 # Find gz-math

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 ##################################################
 # Build a custom protoc plugin
 gz_add_executable(gz_msgs_gen Generator.cc generator_main.cc)
+find_package(Protobuf REQUIRED)
 target_link_libraries(gz_msgs_gen
   protobuf::libprotoc
   protobuf::libprotobuf)


### PR DESCRIPTION
Relates to https://github.com/gazebosim/gz-cmake/issues/9

## Summary

This is removing the need for the custom find script for protobuf. 

## Test it

Compile on CI

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.