### PR TITLE
Default to identity quaternion when not set

### DIFF
--- a/core/include/gz/msgs/convert/Pose.hh
+++ b/core/include/gz/msgs/convert/Pose.hh
@@ -40,8 +40,17 @@ inline void Set(gz::msgs::Pose *_msg, const gz::math::Pose3d &_data)
 
 inline void Set(gz::math::Pose3d *_data, const gz::msgs::Pose &_msg)
 {
-  auto pos = Convert(_msg.position());
-  auto orientation = Convert(_msg.orientation());
+  gz::math::Vector3d pos;
+  gz::math::Quaterniond orientation;
+
+  if (_msg.has_position())
+    pos = Convert(_msg.position());
+
+  // This bit is critical.  If orientation hasn't been set in the message,
+  // then we want the quaternion to default to identity.
+  if (_msg.has_orientation())
+    orientation = Convert(_msg.orientation());
+
   _data->Set(pos, orientation);
 }
 

--- a/test/integration/Utility_TEST.cc
+++ b/test/integration/Utility_TEST.cc
@@ -123,6 +123,23 @@ TEST(UtilityTest, ConvertMsgPoseToMath)
 }
 
 /////////////////////////////////////////////////
+TEST(UtilityTest, ConvertMsgPoseToMathIdentity)
+{
+  // Setting position but not orientation should still
+  // result in a valid identity quaternion
+  msgs::Pose msg;
+  msg.mutable_position()->set_x(1.0);
+  msg.mutable_position()->set_y(2.0);
+  msg.mutable_position()->set_z(2.0);
+
+  math::Pose3d v = msgs::Convert(msg);
+  EXPECT_TRUE(math::equal(v.Rot().W(), 1.0));
+  EXPECT_TRUE(math::equal(v.Rot().X(), 0.0));
+  EXPECT_TRUE(math::equal(v.Rot().Y(), 0.0));
+  EXPECT_TRUE(math::equal(v.Rot().Z(), 0.0));
+}
+
+/////////////////////////////////////////////////
 TEST(MsgsTest, ConvertMathColorToMsgs)
 {
   msgs::Color msg = msgs::Convert(math::Color(.1f, .2f, .3f, 1.0f));


### PR DESCRIPTION
# 🦟 Bug fix

Fixes PoseVector test from here: https://github.com/gazebosim/gz-sim/pull/2087#issuecomment-1698315179

Previously, when quaternion wasn't set in a message (all zeros), we would return an identity quaternion.  This adjusts the new conversion to match that.

