### PR TITLE
Add missing <functional> header

### DIFF
--- a/core/include/gz/msgs/PointCloudPackedUtils.hh
+++ b/core/include/gz/msgs/PointCloudPackedUtils.hh
@@ -24,6 +24,7 @@
 #include <gz/msgs/pointcloud_packed.pb.h>
 
 #include <cstdarg>
+#include <functional>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/core/src/DynamicFactory.hh
+++ b/core/src/DynamicFactory.hh
@@ -30,6 +30,7 @@
 #pragma warning(pop)
 #endif
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Found when building from source on 22.04 with clang-14.