### PR TITLE
Set GZ_TOOLS_VER to 2 for consistency with rest of Garden and Harmonic libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GZ_MATH_VER ${gz-math7_VERSION_MAJOR})
 # Note that CLI files are installed regardless of whether the dependency is
 # available during build time
 find_program(HAVE_GZ_TOOLS gz)
-set(GZ_TOOLS_VER 1)
+set(GZ_TOOLS_VER 2)
 
 #--------------------------------------
 # Find Tinyxml2


### PR DESCRIPTION


# 🦟 Bug fix

All other Garden and Harmonic libraries install the auto-completion to `share/gz/gz2.completion.d/`, while gz-tools install them to `share/gz/gz1.completion.d/`, I guess this was just a typo/leftover.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
