### PR TITLE
Fix cross-compilation support for gz-msg10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,34 +25,49 @@ gz_configure_project(VERSION_SUFFIX
 #============================================================================
 
 # Cross-compilation related options
-# In a cross-compilation scenario, it is possible that the gz_msgs_gen
+# In a cross-compilation scenario, it is possible that the 
+# ${PROJECT_NAME}_protoc_plugin
 # generator compiled for the target machine cannot be used to generate
-# the C++ code corresponding to the .proto definition. For this scenario,
-# the following two options can be used as follows.
+# the C++ code corresponding to the .proto definition.
+# Similarly, it is possible that Python3::Interpreter and protobuf::protoc
+# found via find_package are not executable that can be run during the build.
+# To avoid, that the following options can be used as follows.
 # First of all, gz-msgs is compiled targeting the host machine, and in the
-# build targeting the host, the INSTALL_GZ_MSGS_GEN_EXECUTABLE option is
-# enabled:
-# > cmake -DINSTALL_GZ_MSGS_GEN_EXECUTABLE:BOOL=ON ..
-# ensuring that the gz_msgs_gen is installed in
-# <host_install_prefix>/bin/gz_msgs_gen . Then, the same version of gz-msgs
+# build targeting the host, ensuring that the ${PROJECT_NAME}_protoc_plugin
+# is installed in <host_install_prefix>/bin/${PROJECT_NAME}_protoc_plugin . 
+# Then, the same version of gz-msgs
 # can be cross-compiled, and in the cross-compilation build the location of the
-# host gz_msgs_gen is specified via the GZ_MSGS_GEN_EXECUTABLE
-# CMake cache variable:
-# > cmake -GZ_MSGS_GEN_EXECUTABLE=<host_install_prefix>/bin/gz_msgs_gen ..
-
-option(
-  INSTALL_GZ_MSGS_GEN_EXECUTABLE
-  "Install the gz_msgs_gen executable."
-  OFF)
-
-mark_as_advanced(INSTALL_GZ_MSGS_GEN_EXECUTABLE)
+# host gz_msgs_gen is specified via the GZ_MSGS_GEN_EXECUTABLE CMake option.
+# Similarly to gz-msgs, also a copy of protoc and of the Python interpreter need
+# to be installed in the host at <host_install_prefix>/bin, and they can be passed
+# to the build appropriate CMake options:
+# > cmake -Dgz-msgs<MajVer>_PROTO_GENERATOR_PLUGIN=gz-msgs<MajVer>_protoc_plugin
+# >       -Dgz-msgs<MajVer>_PROTOC_EXECUTABLE=<host_install_prefix>/bin/protoc
+# >       -Dgz-msgs<MajVer>_PYTHON_INTERPRETER=<host_install_prefix>/bin/python 
+# >        ..
+# In case the gz-msgs CMake functions are used also in downstream projects, 
+# the same variables can be passed when configuring the downsream projects.
 
 set(
-  GZ_MSGS_GEN_EXECUTABLE
-  "$<TARGET_FILE:gz_msgs_gen>"
+  ${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN
+  "${PROJECT_NAME}_protoc_plugin"
   CACHE STRING
-  "gz_msgs_gen executable used in the gz_msgs_protoc CMake function.")
-mark_as_advanced(GZ_MSGS_GEN_EXECUTABLE)
+  "gz_msgs_gen executable used in the gz-msgs CMake functions.")
+mark_as_advanced(${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN)
+
+set(
+  ${PROJECT_NAME}_PROTOC_EXECUTABLE
+  protobuf::protoc
+  CACHE STRING
+  "protoc target or executable used in the gz-msgs CMake functions.")
+mark_as_advanced(${PROJECT_NAME}_PROTOC_EXECUTABLE)
+
+set(
+  ${PROJECT_NAME}_PYTHON_INTERPRETER
+  Python3::Interpreter
+  CACHE STRING
+  "python target or executable used in the gz-msgs CMake functions.")
+mark_as_advanced(${PROJECT_NAME}_PYTHON_INTERPRETER)
 
 # Python interfaces vars
 option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION

--- a/cmake/gz_msgs_factory.cmake
+++ b/cmake/gz_msgs_factory.cmake
@@ -6,7 +6,7 @@
 # One value arguments:
 #   FACTORY_GEN_SCRIPT  - Location of the factory generator script
 #   PROTO_PACKAGE       - Protobuf package the file belongs to (e.g. "gz.msgs")
-#   PROTOC_EXEC         - Path to protoc
+#   PYTHON_INTERPRETER  - Target or path to the Python interpreter to use to execute the generator script
 #   OUTPUT_CPP_DIR      - Path where C++ files are saved
 #   OUTPUT_CPP_HH_VAR   - A CMake variable name containing a list that the C++ headers should be appended to
 #   OUTPUT_CPP_CC_VAR   - A Cmake variable name containing a list that the C++ sources should be appended to
@@ -18,12 +18,18 @@ function(gz_msgs_factory)
   set(oneValueArgs
     FACTORY_GEN_SCRIPT
     PROTO_PACKAGE
+    PYTHON_INTERPRETER
     OUTPUT_CPP_DIR
     OUTPUT_CPP_HH_VAR
     OUTPUT_CPP_CC_VAR)
   set(multiValueArgs INPUT_PROTOS PROTO_PATH)
 
   cmake_parse_arguments(gz_msgs_factory "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Default values for optional parameters
+  if (NOT DEFINED gz_msgs_factory_PYTHON_INTERPRETER)
+    set(gz_msgs_factory_PYTHON_INTERPRETER Python3::Interpreter)
+  endif()
 
   _gz_msgs_proto_pkg_to_path(${gz_msgs_factory_PROTO_PACKAGE} proto_package_dir)
 
@@ -57,7 +63,7 @@ function(gz_msgs_factory)
 
   add_custom_command(
     OUTPUT ${output_files}
-    COMMAND Python3::Interpreter
+    COMMAND ${gz_msgs_factory_PYTHON_INTERPRETER}
     ARGS ${gz_msgs_factory_FACTORY_GEN_SCRIPT} ${GENERATE_ARGS}
     DEPENDS
       ${depends_index}

--- a/cmake/gz_msgs_protoc.cmake
+++ b/cmake/gz_msgs_protoc.cmake
@@ -4,6 +4,7 @@
 #   GENERATE_CPP        - generates c++ code for the message if specified
 #   GENERATE_PYTHON     - generates python code for the message if specified
 # One value arguments:
+#   PYTHON_INTERPRETER  - Target or path to the Python interpreter to use to run generation scripts
 #   MSGS_GEN_SCRIPT     - Path to the message generation python script
 #   PROTO_PACKAGE       - Protobuf package the file belongs to (e.g. "gz.msgs")
 #   PROTOC_EXEC         - Path to protoc
@@ -22,6 +23,7 @@
 function(gz_msgs_protoc)
   set(options GENERATE_CPP GENERATE_PYTHON)
   set(oneValueArgs
+    PYTHON_INTERPRETER
     MSGS_GEN_SCRIPT
     PROTO_PACKAGE
     PROTOC_EXEC
@@ -37,6 +39,13 @@ function(gz_msgs_protoc)
   set(multiValueArgs PROTO_PATH DEPENDENCY_PROTO_DESCS)
 
   cmake_parse_arguments(gz_msgs_protoc "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if (NOT DEFINED gz_msgs_protoc_PYTHON_INTERPRETER)
+    set(gz_msgs_protoc_PYTHON_INTERPRETER Python3::Interpreter)
+  endif()
+  if (NOT DEFINED gz_msgs_protoc_PROTOC_EXEC)
+    set(gz_msgs_protoc_PROTOC_EXEC protobuf::protoc)
+  endif()
 
   get_filename_component(ABS_FIL ${gz_msgs_protoc_INPUT_PROTO} ABSOLUTE)
   get_filename_component(FIL_WE ${gz_msgs_protoc_INPUT_PROTO} NAME_WE)
@@ -85,8 +94,14 @@ function(gz_msgs_protoc)
     set(${gz_msgs_protoc_OUTPUT_PYTHON_VAR} ${${gz_msgs_protoc_OUTPUT_PYTHON_VAR}} PARENT_SCOPE)
   endif()
 
+  if(TARGET ${gz_msgs_protoc_PROTOC_EXEC})
+    set(gz_msgs_protoc_PROTOC_EXEC_FILE_ABS_PATH "$<TARGET_FILE:${gz_msgs_protoc_PROTOC_EXEC}>")
+  else()
+    set(gz_msgs_protoc_PROTOC_EXEC_FILE_ABS_PATH ${gz_msgs_protoc_PROTOC_EXEC})
+  endif()
+
   set(GENERATE_ARGS
-      --protoc-exec "$<TARGET_FILE:${gz_msgs_protoc_PROTOC_EXEC}>"
+      --protoc-exec "${gz_msgs_protoc_PROTOC_EXEC_FILE_ABS_PATH}"
       --gz-generator-bin "${gz_msgs_protoc_GZ_PROTOC_PLUGIN}"
       --proto-path "${gz_msgs_protoc_PROTO_PATH}"
       --input-path "${ABS_FIL}"
@@ -118,7 +133,7 @@ function(gz_msgs_protoc)
 
   add_custom_command(
     OUTPUT ${output_files}
-    COMMAND Python3::Interpreter
+    COMMAND ${gz_msgs_protoc_PYTHON_INTERPRETER}
     ARGS ${gz_msgs_protoc_MSGS_GEN_SCRIPT} ${GENERATE_ARGS}
     DEPENDS
       ${ABS_FIL}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -26,13 +26,23 @@ include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_generate.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_protoc.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/gz_msgs_string_utils.cmake)
 
+if(TARGET ${${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN})
+  set(${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN_FILE $<TARGET_FILE:${${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN}>)
+else()
+  set(${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN_FILE ${${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN})
+endif()
+
 gz_msgs_generate_messages_impl(
   MSGS_GEN_SCRIPT
     ${PROJECT_SOURCE_DIR}/tools/gz_msgs_generate.py
   FACTORY_GEN_SCRIPT
     ${PROJECT_SOURCE_DIR}/tools/gz_msgs_generate_factory.py
+  PYTHON_INTERPRETER
+    ${${PROJECT_NAME}_PYTHON_INTERPRETER}
+  PROTOC_EXEC
+    ${${PROJECT_NAME}_PROTOC_EXECUTABLE}
   GZ_PROTOC_PLUGIN
-    $<TARGET_FILE:${PROJECT_NAME}_protoc_plugin>
+    ${${PROJECT_NAME}_PROTO_GENERATOR_PLUGIN_FILE}
   INPUT_PROTOS
     ${proto_files}
   DLLEXPORT_DECL
@@ -54,6 +64,7 @@ gz_msgs_generate_messages_impl(
 )
 
 gz_msgs_generate_desc_impl(
+  PROTOC_EXEC ${${PROJECT_NAME}_PROTOC_EXECUTABLE}
   INPUT_PROTOS ${proto_files}
   PROTO_PATH ${PROJECT_SOURCE_DIR}/proto
   DEPENDENCY_DESCRIPTIONS ${depends_msgs_desc}

--- a/gz-msgs-extras.cmake.in
+++ b/gz-msgs-extras.cmake.in
@@ -28,7 +28,16 @@ set(PROTO_SCRIPT_NAME "@PROJECT_NAME@_generate.py")
 set(FACTORY_SCRIPT_NAME "@PROJECT_NAME@_generate_factory.py")
 
 set(@PROJECT_NAME@_PROTO_PATH ${@PROJECT_NAME@_INSTALL_PATH}/share/protos)
-set(@PROJECT_NAME@_PROTO_GENERATOR_PLUGIN ${@PROJECT_NAME@_INSTALL_PATH}/bin/${PROTOC_NAME})
+# Provide support to override generator executable used during cross-compilation
+if(NOT DEFINED @PROJECT_NAME@_PROTO_GENERATOR_PLUGIN)
+  set(@PROJECT_NAME@_PROTO_GENERATOR_PLUGIN ${@PROJECT_NAME@_INSTALL_PATH}/bin/${PROTOC_NAME})
+endif()
+if(NOT DEFINED @PROJECT_NAME@_PROTOC_EXECUTABLE)
+  set(@PROJECT_NAME@_PROTOC_EXECUTABLE protobuf::protoc)
+endif()
+if(NOT DEFINED @PROJECT_NAME@_PYTHON_INTERPRETER)
+  set(@PROJECT_NAME@_PYTHON_INTERPRETER Python3::Interpreter)
+endif() 
 set(@PROJECT_NAME@_PROTO_GENERATOR_SCRIPT ${@PROJECT_NAME@_INSTALL_PATH}/bin/${PROTO_SCRIPT_NAME})
 set(@PROJECT_NAME@_FACTORY_GENERATOR_SCRIPT ${@PROJECT_NAME@_INSTALL_PATH}/bin/${FACTORY_SCRIPT_NAME})
 
@@ -64,6 +73,10 @@ function(gz_msgs_generate_messages)
 
   cmake_parse_arguments(generate_messages "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   gz_msgs_generate_messages_lib(
+    PYTHON_INTERPRETER
+      ${@PROJECT_NAME@_PYTHON_INTERPRETER}
+    PROTOC_EXEC
+      ${@PROJECT_NAME@_PROTOC_EXECUTABLE}
     MSGS_GEN_SCRIPT
       ${@PROJECT_NAME@_PROTO_GENERATOR_SCRIPT}
     FACTORY_GEN_SCRIPT


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-msgs/issues/390

## Summary

This PR adds a way to cross-compile gz-msgs10. This is done by defining three CMake options to overload all the executable involved in the message generation process. The workflow is documented with a comment in the CMakeLists.txt (the basic idea is that if you need to cross-compile, probably you know that you know how to read basic code). The main difference w.r.t. to the past is that now code generation happens  also in some downstream projects, so this variables need to be set also in downstream projects to cross-compile the downstream projects.

I am not super happy about this solution as it adds a lot of CMake argument parsing boilerplate, but it seem to be working fine and I do not have any concrete idea on how to improve , so I thought it made sense to submit it in this form.

Related past PRs:
* https://github.com/gazebosim/gz-msgs/pull/60
* https://github.com/gazebosim/gz-msgs/pull/319

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

