### PR TITLE
Do not redefine GZ_PYTHON_INSTALL_PATH if it is already defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,16 +108,18 @@ endif()
 # Find Python
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  if(USE_DIST_PACKAGES_FOR_PYTHON)
-    string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+if(NOT GZ_PYTHON_INSTALL_PATH)
+  if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
+    if(USE_DIST_PACKAGES_FOR_PYTHON)
+      string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+    else()
+      # Python3_SITELIB might use dist-packages in some platforms
+      string(REPLACE "dist-packages" "site-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+    endif()
   else()
-    # Python3_SITELIB might use dist-packages in some platforms
-    string(REPLACE "dist-packages" "site-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+    # If not a system installation, respect local paths
+    set(GZ_PYTHON_INSTALL_PATH ${GZ_LIB_INSTALL_DIR}/python)
   endif()
-else()
-  # If not a system installation, respect local paths
-  set(GZ_PYTHON_INSTALL_PATH ${GZ_LIB_INSTALL_DIR}/python)
 endif()
 #============================================================================
 # Configure the build


### PR DESCRIPTION
# 🎉 New feature

## Summary

When doing packaging, it is sometimes useful for advanced users to just tell the build system where to install Python files, without any sort of auto-detection. This was already supported elsewhere (see https://github.com/gazebosim/gz-msgs/blob/0472ba0bb5fe39d8a14499155c68746109d9acf7/core/CMakeLists.txt#L69 and https://github.com/gazebosim/gz-msgs/blob/gz-msgs10/cmake/gz_msgs_generate.cmake#L273) but was not supported at the root level. 



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

