### PR TITLE
Install ruby commands on Windows

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Used only for internal testing.
-set(gz_library_path "${CMAKE_BINARY_DIR}/test/lib/ruby/gz/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
+set(gz_library_path "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/gz/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
 # Generate a configuration file for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: transport0.yaml
 configure_file(
   "${GZ_DESIGNATION}.yaml.in"
-    "${CMAKE_BINARY_DIR}/test/conf/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+  "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml.configured" @ONLY)
+  
+file(GENERATE
+  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml.configured")
 
 # Used for the installed version.
 set(gz_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/gz/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -143,6 +143,4 @@ gz_build_tests(TYPE UNIT
 )
 
 add_subdirectory(include/gz/msgs)
-if(NOT WIN32)
-  add_subdirectory(src/cmd)
-endif()
+add_subdirectory(src/cmd)

--- a/core/src/cmd/CMakeLists.txt
+++ b/core/src/cmd/CMakeLists.txt
@@ -2,8 +2,10 @@
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: cmdtransport0.rb
-set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/ruby/gz/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured_test "${cmd_script_generated_test}.configured")
+set(cmd_script_generated_test 
+  "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/gz/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_script_configured_test 
+  "${CMAKE_CURRENT_BINARY_DIR}/test_cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb.configured")
 
 # Set the library_location variable to the full path of the library file within
 # the build directory.
@@ -24,8 +26,8 @@ file(GENERATE
 # Generate the ruby script that gets installed.
 # Note that the major version of the library is included in the name.
 # Ex: cmdtransport0.rb
-set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured "${cmd_script_generated}.configured")
+set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_script_configured "${CMAKE_CURRENT_BINARY_DIR}/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb.configured")
 
 # Set the library_location variable to the relative path to the library file
 # within the install directory structure.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -14,3 +14,8 @@ if(TARGET INTEGRATION_Factory_TEST)
   target_compile_definitions(INTEGRATION_Factory_TEST PRIVATE
     "-DGZ_MSGS_TEST_PATH=\"${PROJECT_SOURCE_DIR}/test\"")
 endif()
+
+if(TARGET INTEGRATION_gz_TEST)
+    target_compile_definitions(INTEGRATION_gz_TEST PUBLIC 
+      "-DDETAIL_GZ_CONFIG_PATH=\"${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>\"")
+endif()

--- a/test/integration/gz_TEST.cc
+++ b/test/integration/gz_TEST.cc
@@ -27,6 +27,9 @@
 #    define pclose _pclose
 #endif
 
+// DETAIL_GZ_CONFIG_PATH is compiler definition set in CMake.
+#define GZ_CONFIG_PATH DETAIL_GZ_CONFIG_PATH
+
 static const std::string g_version(std::string(GZ_MSGS_VERSION_FULL));
 
 /////////////////////////////////////////////////

--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -19,7 +19,6 @@
 #define GZ_MSGS_TEST_CONFIG_HH_
 
 #define PROJECT_SOURCE_PATH "${PROJECT_SOURCE_DIR}"
-#define GZ_CONFIG_PATH "@CMAKE_BINARY_DIR@/test/conf"
 #define GZ_TEST_LIBRARY_PATH "${PROJECT_BINARY_DIR}/src"
 
 #if (_MSC_VER >= 1400) // Visual Studio 2005


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #28

## Summary
Make sure to `add_subdirectory(cmd)` on Windows. This requires generating the `.rb` and `.yaml` files to folders unique to `$<CONFIG>`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.