### PR TITLE
Fix compiler warning in `generator.cc`

### DIFF
--- a/src/Generator.cc
+++ b/src/Generator.cc
@@ -149,7 +149,7 @@ bool Generator::Generate(const FileDescriptor *_file,
 
     auto ns = getNamespaces(_file->package());
 
-    for (const auto name : ns)
+    for (const auto &name : ns)
         printer.PrintRaw("namespace " + name + " {\n");
 
     for (auto i = 0; i < _file->message_type_count(); ++i)


### PR DESCRIPTION
# 🦟 Bug fix
This PR fixes the following warning I'm getting from my compiler:
```
--- stderr: gz-msgs9
/home/arjoc/ws/gz/garden/src/gz-msgs/src/Generator.cc: In member function ‘virtual bool google::protobuf::compiler::cpp::Generator::Generate(const google::protobuf::FileDescriptor*, const string&, google::protobuf::compiler::OutputDirectory*, std::string*) const’:
/home/arjoc/ws/gz/garden/src/gz-msgs/src/Generator.cc:152:21: warning: loop variable ‘name’ creates a copy from type ‘const std::__cxx11::basic_string<char>’ [-Wrange-loop-construct]
  152 |     for (const auto name : ns)
      |                     ^~~~
/home/arjoc/ws/gz/garden/src/gz-msgs/src/Generator.cc:152:21: note: use reference type to prevent copying
  152 |     for (const auto name : ns)
      |                     ^~~~
      |                     &
---

```
