### PR TITLE
Added motion duration to gui_camera.proto

### DIFF
--- a/proto/gz/msgs/gui_camera.proto
+++ b/proto/gz/msgs/gui_camera.proto
@@ -40,4 +40,6 @@ message GUICamera
 
   /// \brief Type of projection: "perspective" or "orthographic".
   string projection_type       = 6;
+  /// \brief The duration in seconds of the camera motion to the new camera pose.
+  double duration               = 7;
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary
Added 'duration' field to the proto, to allow to set the duration for the 'move to pose' service of the [camera tracking plugin](https://github.com/gazebosim/gz-gui/tree/gz-gui8/src/plugins/camera_tracking).
