### PR TITLE
Add proto message for MaterialColor.

### DIFF
--- a/proto/gz/msgs/material_color.proto
+++ b/proto/gz/msgs/material_color.proto
@@ -22,20 +22,21 @@ option java_package = "com.gz.msgs";
 option java_outer_classname = "MaterialProtos";
 
 /// \ingroup gz.msgs
-/// \interface Material
-/// \brief Information about a material
+/// \interface MaterialColor
+/// \brief Color description for an entities link-visual material.
 
 import "gz/msgs/color.proto";
 import "gz/msgs/header.proto";
 
 message MaterialColor
 {
-
   /// \brief Optional header data
   Header header          = 1;
 
+  /// \brief Name of link-visual.
   string name            = 2;
 
+  /// \brief Name of parent enitity for link-visual.
   string parent_name     = 3;
 
   /// \brief Ambient color
@@ -49,5 +50,4 @@ message MaterialColor
 
   /// \brief Emissive color
   Color emissive         = 7;
-
 }

--- a/proto/gz/msgs/material_color.proto
+++ b/proto/gz/msgs/material_color.proto
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 CogniPilot Foundation
+ * Copyright (C) 2024 Rudis Laboratories LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package gz.msgs;
+option java_package = "com.gz.msgs";
+option java_outer_classname = "MaterialProtos";
+
+/// \ingroup gz.msgs
+/// \interface Material
+/// \brief Information about a material
+
+import "gz/msgs/color.proto";
+import "gz/msgs/header.proto";
+
+message MaterialColor
+{
+
+  /// \brief Optional header data
+  Header header          = 1;
+
+  string name            = 2;
+
+  string parent_name     = 3;
+
+  /// \brief Ambient color
+  Color ambient          = 4;
+
+  /// \brief Diffuse color
+  Color diffuse          = 5;
+
+  /// \brief Specular color
+  Color specular         = 6;
+
+  /// \brief Emissive color
+  Color emissive         = 7;
+
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
The MateriaColor proto message allows for [changing the material colors of an entities visual component](https://github.com/gazebosim/gz-sim/pull/2286) easily and can even be done from [ROS using the gz bridge](https://github.com/gazebosim/ros_gz/pull/486).

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
