### PR TITLE
Add Apply Enum to MaterialColor.

### DIFF
--- a/proto/gz/msgs/material_color.proto
+++ b/proto/gz/msgs/material_color.proto
@@ -31,8 +31,8 @@ import "gz/msgs/header.proto";
 
 message MaterialColor
 {
-  /// \brief Entities to apply material color.
-  enum Apply
+  /// \brief Entities that match to apply material color.
+  enum EntityMatch
   {
     /// \brief Apply material color to first matching entity.
     FIRST = 0;
@@ -42,7 +42,7 @@ message MaterialColor
   }
 
   /// \brief Optional header data
-  Header header          = 1;
+  Header header             = 1;
 
   /// \brief Entity for which material colors are going to be modified.
   ///
@@ -63,23 +63,23 @@ message MaterialColor
   /// * model_name::link_name::visual_name
   /// * link_name::visual_name
   /// * visual_name
-  Entity entity          = 2;
+  Entity entity             = 2;
 
   /// \brief Ambient color
-  Color ambient          = 3;
+  Color ambient             = 3;
 
   /// \brief Diffuse color
-  Color diffuse          = 4;
+  Color diffuse             = 4;
 
   /// \brief Specular color
-  Color specular         = 5;
+  Color specular            = 5;
 
   /// \brief Emissive color
-  Color emissive         = 6;
+  Color emissive            = 6;
 
   /// \brief Specular exponent
-  double shininess       = 7;
+  double shininess          = 7;
 
-  /// \brief Entities to apply material color
-  Apply apply           = 8;
+  /// \brief Entities that match to apply material color.
+  EntityMatch entity_match  = 8;
 }

--- a/proto/gz/msgs/material_color.proto
+++ b/proto/gz/msgs/material_color.proto
@@ -31,6 +31,16 @@ import "gz/msgs/header.proto";
 
 message MaterialColor
 {
+  /// \brief Entities to apply material color.
+  enum Apply
+  {
+    /// \brief Apply material color to first matching entity.
+    FIRST = 0;
+
+    /// \brief Apply material color to all matching entities.
+    ALL = 1;
+  }
+
   /// \brief Optional header data
   Header header          = 1;
 
@@ -69,4 +79,7 @@ message MaterialColor
 
   /// \brief Specular exponent
   double shininess       = 7;
+
+  /// \brief Entities to apply material color
+  Apply apply           = 8;
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Hindsight 20/20 👓  
Adding an Apply enum to change scope of what matching entities material color can be applied to.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
