### PR TITLE
Remove duplicate find_package(Python3) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,6 @@ set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 gz_find_package(gz-math7 REQUIRED)
 set(GZ_MATH_VER ${gz-math7_VERSION_MAJOR})
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 #--------------------------------------
 # Find if command is available. This is used to enable tests.
 # Note that CLI files are installed regardless of whether the dependency is


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-sim/issues/2249.

## Summary

There is already a `find_package(Python3)` call on [line 124](https://github.com/gazebosim/gz-msgs/blob/gz-msgs10_10.1.0/CMakeLists.txt#L124) next to the other python logic, so remove the earlier duplicate call, as there is nothing else that needs it that early.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
