### PR TITLE
Include config.hh to get needed macros

### DIFF
--- a/core/include/gz/msgs/convert/AxisAlignedBox.hh
+++ b/core/include/gz/msgs/convert/AxisAlignedBox.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MSGS_CONVERT_AXISALIGNEDBOX_HH_
 #define GZ_MSGS_CONVERT_AXISALIGNEDBOX_HH_
 
+#include <gz/msgs/config.hh>
 #include <gz/msgs/convert/Vector3.hh>
 
 // Message Headers

--- a/core/include/gz/msgs/convert/Color.hh
+++ b/core/include/gz/msgs/convert/Color.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_COLOR_HH_
 #define GZ_MSGS_CONVERT_COLOR_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/color.pb.h"
 

--- a/core/include/gz/msgs/convert/DiscoveryType.hh
+++ b/core/include/gz/msgs/convert/DiscoveryType.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_DISCOVERYTYPE_HH_
 #define GZ_MSGS_CONVERT_DISCOVERYTYPE_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/discovery.pb.h"
 

--- a/core/include/gz/msgs/convert/FuelMetadata.hh
+++ b/core/include/gz/msgs/convert/FuelMetadata.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_FUELMETADATA_HH_
 #define GZ_MSGS_CONVERT_FUELMETADATA_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/fuel_metadata.pb.h"
 

--- a/core/include/gz/msgs/convert/GeometryType.hh
+++ b/core/include/gz/msgs/convert/GeometryType.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_GEOMETRYTYPE_HH_
 #define GZ_MSGS_CONVERT_GEOMETRYTYPE_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/geometry.pb.h"
 

--- a/core/include/gz/msgs/convert/Inertial.hh
+++ b/core/include/gz/msgs/convert/Inertial.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MSGS_CONVERT_INERTIAL_HH_
 #define GZ_MSGS_CONVERT_INERTIAL_HH_
 
+#include <gz/msgs/config.hh>
 #include <gz/msgs/convert/Pose.hh>
 #include <gz/msgs/convert/Vector3.hh>
 

--- a/core/include/gz/msgs/convert/JointType.hh
+++ b/core/include/gz/msgs/convert/JointType.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_JOINTTYPE_HH_
 #define GZ_MSGS_CONVERT_JOINTTYPE_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/joint.pb.h"
 

--- a/core/include/gz/msgs/convert/PixelFormatType.hh
+++ b/core/include/gz/msgs/convert/PixelFormatType.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_PIXELFORMATTYPE_HH_
 #define GZ_MSGS_CONVERT_PIXELFORMATTYPE_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/image.pb.h"
 

--- a/core/include/gz/msgs/convert/Plane.hh
+++ b/core/include/gz/msgs/convert/Plane.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MSGS_CONVERT_PLANE_HH_
 #define GZ_MSGS_CONVERT_PLANE_HH_
 
+#include <gz/msgs/config.hh>
 #include <gz/msgs/convert/Vector2.hh>
 #include <gz/msgs/convert/Vector3.hh>
 

--- a/core/include/gz/msgs/convert/Pose.hh
+++ b/core/include/gz/msgs/convert/Pose.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MSGS_CONVERT_POSE_HH_
 #define GZ_MSGS_CONVERT_POSE_HH_
 
+#include <gz/msgs/config.hh>
 #include <gz/msgs/convert/Vector3.hh>
 #include <gz/msgs/convert/Quaternion.hh>
 

--- a/core/include/gz/msgs/convert/Quaternion.hh
+++ b/core/include/gz/msgs/convert/Quaternion.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_QUATERNION_HH_
 #define GZ_MSGS_CONVERT_QUATERNION_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/quaternion.pb.h"
 

--- a/core/include/gz/msgs/convert/ShaderType.hh
+++ b/core/include/gz/msgs/convert/ShaderType.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_SHADERTYPE_HH_
 #define GZ_MSGS_CONVERT_SHADERTYPE_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/material.pb.h"
 

--- a/core/include/gz/msgs/convert/SphericalCoordinates.hh
+++ b/core/include/gz/msgs/convert/SphericalCoordinates.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_SPHERICALCOORDINATES_HH_
 #define GZ_MSGS_CONVERT_SPHERICALCOORDINATES_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/spherical_coordinates.pb.h"
 

--- a/core/include/gz/msgs/convert/StdTypes.hh
+++ b/core/include/gz/msgs/convert/StdTypes.hh
@@ -18,6 +18,7 @@
 #define GZ_MSGS_CONVERT_STDTYPES_HH_
 
 #include <gz/math/Helpers.hh>
+#include <gz/msgs/config.hh>
 
 // Message Headers
 #include "gz/msgs/boolean.pb.h"

--- a/core/include/gz/msgs/convert/Vector2.hh
+++ b/core/include/gz/msgs/convert/Vector2.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_VECTOR2_HH_
 #define GZ_MSGS_CONVERT_VECTOR2_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/vector2d.pb.h"
 

--- a/core/include/gz/msgs/convert/Vector3.hh
+++ b/core/include/gz/msgs/convert/Vector3.hh
@@ -17,6 +17,8 @@
 #ifndef GZ_MSGS_CONVERT_VECTOR3_HH_
 #define GZ_MSGS_CONVERT_VECTOR3_HH_
 
+#include <gz/msgs/config.hh>
+
 // Message Headers
 #include "gz/msgs/vector3d.pb.h"
 

--- a/core/include/gz/msgs/convert/make_stubs.py
+++ b/core/include/gz/msgs/convert/make_stubs.py
@@ -46,6 +46,7 @@ template = """/*
 #define GZ_MSGS_CONVERT_{header}_HH_
 
 #include <gz/msgs/Converter.hh>
+#include <gz/msgs/config.hh>
 
 // Message Headers
 {msg_headers}


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-cmake#412.

## Summary

This includes `gz/msgs/config.hh` wherever the `GZ_MSGS_VERSION_NAMESPACE` macro is used in order to provide the macro definition.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
