### PR TITLE
Fix MSVC "possible loss of data" warning

### DIFF
--- a/core/include/gz/msgs/convert/StdTypes.hh
+++ b/core/include/gz/msgs/convert/StdTypes.hh
@@ -47,7 +47,7 @@ inline void Set(gz::msgs::Time *_msg,
         gz::math::durationToSecNsec(_data);
   msgs::Time msg;
   _msg->set_sec(timeSecAndNsecs.first);
-  _msg->set_nsec(timeSecAndNsecs.second);
+  _msg->set_nsec(static_cast<int32_t>(timeSecAndNsecs.second));
 }
 
 inline void Set(std::chrono::steady_clock::duration *_data,


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The warning appears in [`gz-launch`](https://build.osrfoundation.org/job/gz_launch-pr-win/21/consoleFull#console-section-10) and it's due to the fact that we're assigning a `uint64_t` to an `int32_t`. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
