### PR TITLE
Adding cone primitives.

### DIFF
--- a/core/include/gz/msgs/convert/GeometryType.hh
+++ b/core/include/gz/msgs/convert/GeometryType.hh
@@ -41,6 +41,10 @@ inline msgs::Geometry::Type ConvertGeometryType(const std::string &_str)
   {
     result = msgs::Geometry::CAPSULE;
   }
+  else if (_str == "cone")
+  {
+    result = msgs::Geometry::CONE;
+  }
   else if (_str == "cylinder")
   {
     result = msgs::Geometry::CYLINDER;
@@ -98,6 +102,11 @@ inline std::string ConvertGeometryType(const msgs::Geometry::Type _type)
     case msgs::Geometry::CAPSULE:
     {
       result = "capsule";
+      break;
+    }
+  case msgs::Geometry::CONE:
+    {
+      result = "cone";
       break;
     }
     case msgs::Geometry::CYLINDER:

--- a/proto/gz/msgs/particle_emitter.proto
+++ b/proto/gz/msgs/particle_emitter.proto
@@ -55,6 +55,8 @@ message ParticleEmitter
     CYLINDER  = 2;
     /// \brief Ellipsoid emitter.
     ELLIPSOID = 3;
+    /// \brief Cone emitter.
+    CONE = 4;
   }
   /// \brief The emitter type.
   EmitterType type              = 4;

--- a/test/integration/Utility_TEST.cc
+++ b/test/integration/Utility_TEST.cc
@@ -1003,6 +1003,7 @@ TEST(MsgsTest, ConvertMsgsGeometryTypeToString)
   CompareMsgsGeometryTypeToString(msgs::Geometry::BOX);
   CompareMsgsGeometryTypeToString(msgs::Geometry::SPHERE);
   CompareMsgsGeometryTypeToString(msgs::Geometry::CAPSULE);
+  CompareMsgsGeometryTypeToString(msgs::Geometry::CONE);
   CompareMsgsGeometryTypeToString(msgs::Geometry::CYLINDER);
   CompareMsgsGeometryTypeToString(msgs::Geometry::ELLIPSOID);
   CompareMsgsGeometryTypeToString(msgs::Geometry::PLANE);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This helps add the missing cone geometry for primitive/basic parametric shapes:

![conetopple](https://github.com/gazebosim/gz-math/assets/10233412/5fd8f1a1-3a77-4e61-95d5-f053389cd908)
![cone](https://github.com/gazebosim/gz-math/assets/10233412/1c516775-7adb-4318-9c6a-0c09a746a3b0)

And is also valuable for visualizations of emitters/source that typically have conic-based spread as seen in this acoustic attack on an IMU by showing the affected area:

![drone_attack](https://github.com/gazebosim/gz-rendering/assets/10233412/7a6b0dfa-8ad6-42c1-83bc-8385ccc4c81a)

Associated PRs:
- https://github.com/gazebosim/gz-gui/pull/621
- https://github.com/gazebosim/gz-math/pull/594
- https://github.com/gazebosim/gz-msgs/pull/442
- https://github.com/gazebosim/gz-physics/pull/639
- https://github.com/gazebosim/gz-rendering/pull/1003
- https://github.com/gazebosim/gz-sim/pull/2410
- https://github.com/gazebosim/sdformat/pull/1418

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
