### PR TITLE
Enable 24.04 CI, require cmake 3.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-msgs[0-9]?'
+      - 'gz-msgs[0-9]?'
+      - 'main'
 
 jobs:
   jammy-ci:
@@ -8,7 +14,7 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
@@ -17,3 +23,12 @@ jobs:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/examples/generating_custom_msgs/CMakeLists.txt
+++ b/examples/generating_custom_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/examples/using_gz_msgs/CMakeLists.txt
+++ b/examples/using_gz_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/gz-msgs-extras.cmake.in
+++ b/gz-msgs-extras.cmake.in
@@ -22,14 +22,7 @@ include(${@PROJECT_NAME@_DIR}/gz_msgs_factory.cmake)
 include(${@PROJECT_NAME@_DIR}/gz_msgs_generate.cmake)
 
 set(@PROJECT_NAME@_INSTALL_PATH "${@PROJECT_NAME@_DIR}/@PROJECT_CMAKE_EXTRAS_PATH_TO_PREFIX@")
-
-if(CMAKE_VERSION VERSION_LESS "3.20.0") 
-  file(TO_CMAKE_PATH @PROJECT_NAME@_INSTALL_PATH NORMALIZED_PATH)  # Converts native path to CMake style with forward slashes.
-  get_filename_component(ABSOLUTE_PATH "${NORMALIZED_PATH}" ABSOLUTE)  # Extracts the absolute path component.
-  set(@PROJECT_NAME@_INSTALL_PATH "${ABSOLUTE_PATH}")  # Stores the normalized absolute path back to the original variable.
-else()
-  cmake_path(NORMAL_PATH @PROJECT_NAME@_INSTALL_PATH OUTPUT_VARIABLE @PROJECT_NAME@_INSTALL_PATH)
-endif()
+cmake_path(NORMAL_PATH @PROJECT_NAME@_INSTALL_PATH OUTPUT_VARIABLE @PROJECT_NAME@_INSTALL_PATH)
 
 set(PROTOC_NAME "$<TARGET_FILE_NAME:@PROJECT_NAME@_protoc_plugin>")
 set(PROTO_SCRIPT_NAME "@PROJECT_NAME@_generate.py")

--- a/tutorials/cppgetstarted.md
+++ b/tutorials/cppgetstarted.md
@@ -59,7 +59,7 @@ int main()
 To compile the code create a `CMakeLists.txt`:
 
 ```
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 # Find the Gazebo msgs library
 find_package(gz-msgs11 QUIET REQUIRED)

--- a/tutorials/message_generation.md
+++ b/tutorials/message_generation.md
@@ -127,7 +127,7 @@ The `cmake` functionality is exported from the `gz-msgs` library, via the `gz-cm
 To make the functions available, simply `find_package(gz-msgs11)` in your `CMakeLists.txt`:
 
 ```cmake
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(my_custom_package VERSION 0.0.1)
 find_package(gz-cmake4 REQUIRED)
 find_package(gz-msgs11 REQUIRED)


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/issues/350.

## Summary

This adds a GitHub workflow using Noble and increases our minimum required cmake version to 3.22.1 since we are already requiring that in gz-cmake4. It also removes some old code to support older versions of cmake.

## Test it

Look at the 24.04 CI results.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
