### PR TITLE
Remove Cone shape from particle emitter

### DIFF
--- a/proto/gz/msgs/particle_emitter.proto
+++ b/proto/gz/msgs/particle_emitter.proto
@@ -55,8 +55,6 @@ message ParticleEmitter
     CYLINDER  = 2;
     /// \brief Ellipsoid emitter.
     ELLIPSOID = 3;
-    /// \brief Cone emitter.
-    CONE = 4;
   }
   /// \brief The emitter type.
   EmitterType type              = 4;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Similar to https://github.com/gazebosim/sdformat/pull/1434, let's only add cone shape to particle emitters when there is support for it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

