### PR TITLE
Deprecate LOCAL2 in `SphericalCoordinates`

### DIFF
--- a/core/include/gz/msgs/convert/SphericalCoordinates.hh
+++ b/core/include/gz/msgs/convert/SphericalCoordinates.hh
@@ -34,7 +34,9 @@ inline namespace GZ_MSGS_VERSION_NAMESPACE {
 inline msgs::SphericalCoordinatesType ConvertCoord(
   const math::SphericalCoordinates::CoordinateType &_sc)
 {
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   auto result = msgs::SphericalCoordinatesType::LOCAL2;
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
   switch (_sc)
   {
     case math::SphericalCoordinates::CoordinateType::ECEF:
@@ -49,9 +51,11 @@ inline msgs::SphericalCoordinatesType ConvertCoord(
     case math::SphericalCoordinates::CoordinateType::LOCAL:
       result = msgs::SphericalCoordinatesType::LOCAL;
       break;
+    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     case math::SphericalCoordinates::CoordinateType::LOCAL2:
       result = msgs::SphericalCoordinatesType::LOCAL2;
       break;
+    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
     default:
       std::cerr << "Invalid coordinate type passed" << std::endl;
   }
@@ -72,12 +76,16 @@ inline math::SphericalCoordinates::CoordinateType Convert(
       return math::SphericalCoordinates::CoordinateType::SPHERICAL;
     case msgs::SphericalCoordinatesType::LOCAL:
       return math::SphericalCoordinates::CoordinateType::LOCAL;
+    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     case msgs::SphericalCoordinatesType::LOCAL2:
       return math::SphericalCoordinates::CoordinateType::LOCAL2;
+    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
     default:
       std::cerr << "Invalid coordinate type passed" << std::endl;
   }
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   return math::SphericalCoordinates::CoordinateType::LOCAL2;
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 
 /////////////////////////////////

--- a/proto/gz/msgs/spherical_coordinates.proto
+++ b/proto/gz/msgs/spherical_coordinates.proto
@@ -39,12 +39,10 @@ enum SphericalCoordinatesType
   GLOBAL = 2;
 
   /// \brief Heading-adjusted tangent plane (X, Y, Z)
-  /// This has kept a bug for backwards compatibility, use
-  /// LOCAL2 for the correct behaviour.
   LOCAL = 3;
 
   /// \brief Heading-adjusted tangent plane (X, Y, Z)
-  LOCAL2 = 4;
+  LOCAL2 = 4  [deprecated=true];
 }
 
 message SphericalCoordinates

--- a/test/integration/Utility_TEST.cc
+++ b/test/integration/Utility_TEST.cc
@@ -354,8 +354,10 @@ TEST(MsgsTest, ConvertMathSphericalCoordinatesToMsgs)
     msgs::ConvertCoord(math::SphericalCoordinates::CoordinateType::SPHERICAL));
   EXPECT_EQ(msgs::SphericalCoordinatesType::LOCAL,
     msgs::ConvertCoord(math::SphericalCoordinates::CoordinateType::LOCAL));
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_EQ(msgs::SphericalCoordinatesType::LOCAL2,
     msgs::ConvertCoord(math::SphericalCoordinates::CoordinateType::LOCAL2));
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   EXPECT_EQ(math::SphericalCoordinates::CoordinateType::ECEF,
     msgs::Convert(msgs::SphericalCoordinatesType::ECEF));
@@ -365,8 +367,11 @@ TEST(MsgsTest, ConvertMathSphericalCoordinatesToMsgs)
     msgs::Convert(msgs::SphericalCoordinatesType::SPHERICAL));
   EXPECT_EQ(math::SphericalCoordinates::CoordinateType::LOCAL,
     msgs::Convert(msgs::SphericalCoordinatesType::LOCAL));
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_EQ(math::SphericalCoordinates::CoordinateType::LOCAL2,
     msgs::Convert(msgs::SphericalCoordinatesType::LOCAL2));
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
 
   auto msg = msgs::Convert(
       math::SphericalCoordinates(
@@ -452,10 +457,12 @@ TEST(MsgsTest, ConvertMsgsSphericalCoordinatesTypeToMath)
     math::SphericalCoordinates::CoordinateType::SPHERICAL);
   EXPECT_EQ(Convert(msgs::SphericalCoordinatesType::LOCAL),
     math::SphericalCoordinates::CoordinateType::LOCAL);
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_EQ(Convert(msgs::SphericalCoordinatesType::LOCAL2),
     math::SphericalCoordinates::CoordinateType::LOCAL2);
   EXPECT_EQ(Convert((msgs::SphericalCoordinatesType)500000),
     math::SphericalCoordinates::CoordinateType::LOCAL2);
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 
 /////////////////////////////////////////////////
@@ -473,12 +480,14 @@ TEST(MsgsTest, ConvertMathSphericalCoordinatedTypeToMsg)
   EXPECT_EQ(msgs::ConvertCoord(
       math::SphericalCoordinates::CoordinateType::LOCAL),
     msgs::SphericalCoordinatesType::LOCAL);
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_EQ(msgs::ConvertCoord(
       math::SphericalCoordinates::CoordinateType::LOCAL2),
     msgs::SphericalCoordinatesType::LOCAL2);
   EXPECT_EQ(msgs::ConvertCoord(
     (math::SphericalCoordinates::CoordinateType)500000),
     msgs::SphericalCoordinatesType::LOCAL2);
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

cc: @peci

With the introduction of https://github.com/gazebosim/gz-math/pull/616. We will be deprecating `LOCAL2` as a work around in favor or `LOCAL`. As part of this change, its probably a good idea to update `gz-msgs` as well.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

