### PR TITLE
Remove link from message generation tutorial.

### DIFF
--- a/tutorials/message_generation.md
+++ b/tutorials/message_generation.md
@@ -21,8 +21,7 @@ Gazebo message definitions are stored in the
 Messages may additionally belong to a `package`, which allows for convenient
 namespacing or grouping of common messages.
 Currently, all `gz-msgs` definitions reside in the `gz.msgs` package, which
-generates the corresponding `gz::msgs` namespace in C++ and `gz.msgs` in
-Python.
+generates the corresponding `gz::msgs` namespace in C++.
 
 ### Proto files
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

An incorrect link is generated in the [message generation tutorial](https://gazebosim.org/api/msgs/11/messagegeneration.html).

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.