### PR TITLE
WheelSlipParametersCmd: add friction

### DIFF
--- a/proto/gz/msgs/wheel_slip_parameters_cmd.proto
+++ b/proto/gz/msgs/wheel_slip_parameters_cmd.proto
@@ -69,4 +69,15 @@ message WheelSlipParametersCmd
   /// the linear wheel spin velocity and divided by the wheel normal force
   /// parameter specified in the sdf.
   double slip_compliance_longitudinal = 5;
+
+  /// \brief Lateral friction coefficient.
+  ///
+  /// Friction coefficient that should be applied with the pyramid friction
+  /// model in the lateral wheel direction.
+  double friction_lateral      = 6;
+  /// \brief Longitudinal friction coefficient.
+  ///
+  /// Friction coefficient that should be applied with the pyramid friction
+  /// model in the longitudinal wheel direction.
+  double friction_longitudinal = 7;
 }


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/1845

## Summary

The goal for https://github.com/gazebosim/gz-sim/issues/1845 is to show how to use gz-transport parameters to emulate ROS parameters, with the parameters used by the [gazebo_ros_wheel_slip plugin](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/ros2/gazebo_plugins/src/gazebo_ros_wheel_slip.cpp) as a motivating example with the `wheel_slip_parameters_cmd.proto` message type. Since support for friction coefficients was added to that plugin in https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1393, this pull request adds corresponding lateral and longitudinal friction parameters to the proto message.


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
