### PR TITLE
gz-msgs-extras: Do not call find_package(Python3) if gz-msgs<majVer>_PYTHON_INTERPRETER is defined

### DIFF
--- a/gz-msgs-extras.cmake.in
+++ b/gz-msgs-extras.cmake.in
@@ -14,8 +14,6 @@
 
 # copied from gz-msgs/gz-msgs-extras.cmake
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 include(${@PROJECT_NAME@_DIR}/gz_msgs_string_utils.cmake)
 include(${@PROJECT_NAME@_DIR}/gz_msgs_protoc.cmake)
 include(${@PROJECT_NAME@_DIR}/gz_msgs_factory.cmake)
@@ -37,6 +35,7 @@ if(NOT DEFINED @PROJECT_NAME@_PROTOC_EXECUTABLE)
   set(@PROJECT_NAME@_PROTOC_EXECUTABLE protobuf::protoc)
 endif()
 if(NOT DEFINED @PROJECT_NAME@_PYTHON_INTERPRETER)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
   set(@PROJECT_NAME@_PYTHON_INTERPRETER Python3::Interpreter)
 endif()
 set(@PROJECT_NAME@_PROTO_GENERATOR_SCRIPT ${@PROJECT_NAME@_INSTALL_PATH}/bin/${PROTO_SCRIPT_NAME})


### PR DESCRIPTION
# 🦟 Bug fix

Do not raise error in cross-compilation context if `gz-msgs<majorVer>__PYTHON_INTERPRETER` is defined.  

## Summary

When  `gz-msgs<majorVer>__PYTHON_INTERPRETER` is defined, its value will be used instead of `Python3::Interpreter`. For this reason, it does not make sense to search for Python3 if `gz-msgs<majorVer>__PYTHON_INTERPRETER`  is defined. Moving the `find_package` there simplifies the cross-compilation of gz packages, as it remove the need for CMake to find a working Python interpeter.

It would be cool (regardless of the value of `gz-msgs<majorVer>__PYTHON_INTERPRETER`) to only search for Python3 if one project actually calls `gz_msgs_generate_messages`, and not if a project just call (sometimes transitively) `find_package(gz-msgs<majorVer>)`. However, this would be a more complex change, while the change of this PR is simple and self-contained.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

