### PR TITLE
Fix bash completion script install path

### DIFF
--- a/core/cmd/CMakeLists.txt
+++ b/core/cmd/CMakeLists.txt
@@ -34,4 +34,4 @@ install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/msgs${PROJECT_VERSION_MAJOR}.bash_completion.sh
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${GZ_TOOLS_VER}.completion.d)
+    ${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${GZ_TOOLS_VER}.completion.d)


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Fix bash completion script installation path. Issue reported when building gz-msgs-vendor for rolling:

```
23:29:16 CMake Error at core/cmd/cmake_install.cmake:82 (file):
23:29:16   file cannot create directory:
23:29:16   /opt/ros/rolling/opt/gz_msgs_vendor/share/gz/gz2.completion.d.  Maybe need
23:29:16   administrative privileges.
```

updated install path to be consistent with other pacakges, e.g. see install path in [gz-transport](https://github.com/gazebosim/gz-transport/blob/gz-transport14/src/cmd/CMakeLists.txt#L130) and [sdformat](https://github.com/gazebosim/sdformat/blob/551cb998e8bd1af84e0196b337098ff686ea47a0/src/cmd/CMakeLists.txt#L65)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

