### PR TITLE
Return only unique message types in `MessageFactory::Types` function

### DIFF
--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -62,6 +62,11 @@ MessageFactory::MessagePtr MessageFactory::New(
   {
     type = kGzMsgsPrefix + _msgType.substr(8);
   }
+  // Convert ".gz.msgs." prefix
+  else if (_msgType.find(".gz.msgs.") == 0)
+  {
+    type = kGzMsgsPrefix + _msgType.substr(9);
+  }
   // Convert ".gz_msgs." prefix
   else if (_msgType.find(".gz_msgs.") == 0)
   {

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <unordered_set>
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4146 4251)
@@ -64,11 +66,6 @@ MessageFactory::MessagePtr MessageFactory::New(
   else if (_msgType.find(".gz_msgs.") == 0)
   {
     type = kGzMsgsPrefix +  _msgType.substr(9);
-  }
-  // Convert ".gz.msgs." prefix
-  else if (_msgType.find(".gz.msgs.") == 0)
-  {
-    type = kGzMsgsPrefix + _msgType.substr(9);
   }
   else
   {
@@ -130,15 +127,21 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 {
   _types.clear();
 
+  // Add the types loaded from descriptor files
+  std::vector<std::string> dynTypes;
+  this->dynamicFactory->Types(dynTypes);
+
+  // Use set to remove duplicates
+  std::unordered_set<std::string> typesSet(dynTypes.begin(), dynTypes.end());
+
   // Return the list of all known message types.
   std::map<std::string, FactoryFn>::const_iterator iter;
   for (iter = msgMap.begin(); iter != msgMap.end(); ++iter)
   {
-    _types.push_back(iter->first);
+    typesSet.insert(iter->first);
   }
 
-  // Add the types loaded from descriptor files
-  this->dynamicFactory->Types(_types);
+  std::copy(typesSet.begin(), typesSet.end(), std::back_inserter(_types));
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-msgs/issues/470

## Summary

The `MessageFactory::Type` function returns duplicate message types. This is because the list of known message types overlaps with  types loaded from descriptor files so the function essentially return two of the same message types. This PR uses a set to filter out duplicates. A potential todo is to return an set instead of a vector.

~~I also removed an extra duplicate check in the `New` function (probably leftover from ign -> gz migration)~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
