### PR TITLE
Add rule to build python version of protos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ load(
     "gz_proto_library",
 )
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 package(
     default_applicable_licenses = [GZ_ROOT + "msgs:license"],
@@ -88,6 +89,11 @@ proto_library(
     deps = [
         "@com_google_protobuf//:any_proto",
     ],
+)
+
+py_proto_library(
+    name = "gzmsgs_proto_py_pb2",
+    deps = [":gzmsgs_proto"]
 )
 
 gz_proto_library(


### PR DESCRIPTION


# 🎉 New feature

Depends on https://github.com/gazebosim/gz-bazel/pull/77

## Summary

Add rule in bazel build file to build python version of proto files

## Test it

Setup up [gz-bazel](https://github.com/gazebosim/gz-bazel) worksspace, update to `update_rules_python_version` branch (see https://github.com/gazebosim/gz-bazel/pull/77) and build:

```
bazel build //msgs/...
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

