### PR TITLE
Prepare for 5.11.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-msgs5 VERSION 5.11.0)
+project(ignition-msgs5 VERSION 5.11.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,20 @@
 ## Ignition Msgs 5.x
 
+### Gazebo Msgs 5.11.1 (2025-01-29)
+
+1. GzProtobuf: Do not require version 3
+    * [Pull request #346](https://github.com/gazebosim/gz-msgs/pull/346)
+
+1. Infrastructure
+    * [Pull request #409](https://github.com/gazebosim/gz-msgs/pull/409)
+    * [Pull request #331](https://github.com/gazebosim/gz-msgs/pull/331)
+
+1. Rename COPYING to LICENSE
+    * [Pull request #330](https://github.com/gazebosim/gz-msgs/pull/330)
+
+1. Fix typo in changelog
+    * [Pull request #314](https://github.com/gazebosim/gz-msgs/pull/314)
+
 ### Ignition Msgs 5.11.0 (2022-10-10)
 
 1. Ignition to Gazebo renaming.


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.11.1 release.

Comparison to 5.11.0: https://github.com/gazebosim/gz-msgs/compare/ignition-msgs5_5.11.0...ign-msgs5

Part of https://github.com/gazebo-tooling/release-tools/issues/1252

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.