### PR TITLE
docs: fix typo in tutorials/message_generation.md

### DIFF
--- a/tutorials/message_generation.md
+++ b/tutorials/message_generation.md
@@ -62,7 +62,7 @@ message FooMessage
 
 Note that each field has a corresponding *field number*.
 Each field must be given an ID between `1` and `536,870,911`, with the following
-restrctions (from the [language guide](https://protobuf.dev/programming-guides/proto3/#assigning)):
+restrictions (from the [language guide](https://protobuf.dev/programming-guides/proto3/#assigning)):
 
 * The given number must be unique among all fields for that message.
 * Field numbers `19,000` to `19,999` are reserved for the Protocol Buffers implementation.


### PR DESCRIPTION
Corrected "restrctions" to "restrictions" and "entrypoint" to "entry point" in the documentation.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #493 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Iterated through all the .md and .md.in files. Found 2 typos in the tutorials/message_generation.md file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
