### PR TITLE
Restore support for non-qualified message names

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -35,11 +35,6 @@ release will remove the deprecated code.
   const msgs::SphericalCoordinatesType &_sc)`
       does not accept `msgs::SphericalCoordinatesType::LOCAL2` anymore.
 
-1. **MessageFactory.hh**
-    + The function `MessageFactory::MessagePtr MessageFactory::New(
-    const std::string &_msgType)` does not accept non-fully qualified names
-    anymore.
-
 ## Gazebo Msgs 10.X to 11.X
 ### Deprecations
 

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -94,6 +94,19 @@ MessageFactory::MessagePtr MessageFactory::New(
   };
 
   auto ret = getMessagePtr(type);
+
+  // Message was not found in either static or dynamic message types,
+  // try again adding the gz.msgs prefix
+  if (nullptr == ret)
+  {
+    ret = getMessagePtr(kGzMsgsPrefix + type);
+    if (nullptr != ret)
+    {
+      std::cerr << "Message (" << kGzMsgsPrefix + type
+          << ") was retrieved with non-fully qualified name. "
+          << "This behavior is deprecated in msgs12" << std::endl;
+    }
+  }
   return ret;
 }
 

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -102,6 +102,8 @@ MessageFactory::MessagePtr MessageFactory::New(
     ret = getMessagePtr(kGzMsgsPrefix + type);
     if (nullptr != ret)
     {
+      // Do not remove this until support is added to gz-transport:
+      // https://github.com/gazebosim/gz-transport/issues/435
       std::cerr << "Message (" << kGzMsgsPrefix + type
           << ") was retrieved with non-fully qualified name. "
           << "This behavior is deprecated in msgs12" << std::endl;

--- a/test/integration/Factory_TEST.cc
+++ b/test/integration/Factory_TEST.cc
@@ -100,7 +100,7 @@ TEST(FactoryTest, NewWithMalformedData)
 TEST(FactoryTest, DeprecatedNonFullyQualified)
 {
   auto msg = Factory::New("StringMsg");
-  EXPECT_TRUE(msg.get() == nullptr);
+  EXPECT_TRUE(msg.get() != nullptr);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1309.

## Summary

Support for non-qualified message names in `MessageFactory` was removed in #476, but this is not yet supported in gz-transport (see https://github.com/gazebosim/gz-transport/pull/634). Restore the functionality for now to facilitate version bumps and then try removing it later.

## Test it

Check CI

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
