### PR TITLE
sensor.proto: use NavSatSensor type

### DIFF
--- a/proto/gz/msgs/sensor.proto
+++ b/proto/gz/msgs/sensor.proto
@@ -35,7 +35,7 @@ import "gz/msgs/imu_sensor.proto";
 import "gz/msgs/lidar_sensor.proto";
 import "gz/msgs/logical_camera_sensor.proto";
 import "gz/msgs/magnetometer_sensor.proto";
-import "gz/msgs/navsat.proto";
+import "gz/msgs/navsat_sensor.proto";
 import "gz/msgs/pose.proto";
 
 message Sensor
@@ -108,5 +108,5 @@ message Sensor
   AirSpeedSensor air_speed             = 21;
 
   /// \brief Description of a GNSS sensor
-  NavSat navsat          = 22;
+  NavSatSensor navsat    = 22;
 }


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to https://github.com/gazebosim/gz-msgs/pull/476. Needed by https://github.com/gazebosim/gz-sim/pull/2910.

## Summary

There are separate `navsat.proto` and `navsat_sensor.proto` messages. All the subfields of `sensor.proto` use `_sensor.proto` messages, except for `navsat`, which I assume was a typo in #476. This changes the `navsat` field from `NavSat` type to `NavSatSensor` type.

The Migration guide doesn't need to be changed.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
