### PR TITLE
Fix gz msgs ruby command

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -2,4 +2,5 @@
 make install
 # Test gz command
 export GZ_CONFIG_PATH=/usr/local/share/gz
+export LD_LIBRARY_PATH=/usr/local/lib
 gz msg

--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -1,2 +1,4 @@
 # It's necessary to install the python modules for the test.
 make install
+# Test gz command
+gz msg

--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -1,4 +1,5 @@
 # It's necessary to install the python modules for the test.
 make install
 # Test gz command
+export GZ_CONFIG_PATH=/usr/local/share/gz
 gz msg

--- a/core/cmd/cmdmsgs.rb.in
+++ b/core/cmd/cmdmsgs.rb.in
@@ -30,7 +30,7 @@ class Cmd
     unless Pathname.new(exe_name).absolute?
       # We're assuming that the library path is relative to the current
       # location of this script.
-      exe_name = File.expand_path(File.join(File.dirname(__FILE__), LIBRARY_NAME))
+      exe_name = File.expand_path(File.join(File.dirname(__FILE__), exe_name))
     end
 
     # Drop command from list of arguments


### PR DESCRIPTION
# 🦟 Bug fix

Fixed #462.

## Summary

The `gz msg` command has an incorrect path to the `gz-msgs` standalone executable, so it fails to run. This fixes the path.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
