### PR TITLE
[bazel] Fix visibility for tools/gz_msgs_generate.bzl

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,6 +58,7 @@ cc_binary(
         "core/generator_lite/Generator.hh",
         "core/generator_lite/generator_main.cc",
     ],
+    visibility = ["//:__subpackages__"],
     deps = [
         "@com_google_protobuf//:protobuf",
         "@com_google_protobuf//:protoc_lib",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes bazel build for downstream targets that use the `gz_proto_library` rule exported from `tools/gz_msgs_generate.bzl`. This needs the `gz_msgs_gen` tool to be visible to subpackages.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
