### PR TITLE
Revert "Restore support for non-qualified message names (#512)"

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -39,6 +39,11 @@ release will remove the deprecated code.
   const msgs::SphericalCoordinatesType &_sc)`
       does not accept `msgs::SphericalCoordinatesType::LOCAL2` anymore.
 
+1. **MessageFactory.hh**
+    + The function `MessageFactory::MessagePtr MessageFactory::New(
+    const std::string &_msgType)` does not accept non-fully qualified names
+    anymore.
+
 ## Gazebo Msgs 10.X to 11.X
 ### Deprecations
 

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -94,21 +94,6 @@ MessageFactory::MessagePtr MessageFactory::New(
   };
 
   auto ret = getMessagePtr(type);
-
-  // Message was not found in either static or dynamic message types,
-  // try again adding the gz.msgs prefix
-  if (nullptr == ret)
-  {
-    ret = getMessagePtr(kGzMsgsPrefix + type);
-    if (nullptr != ret)
-    {
-      // Do not remove this until support is added to gz-transport:
-      // https://github.com/gazebosim/gz-transport/issues/435
-      std::cerr << "Message (" << kGzMsgsPrefix + type
-          << ") was retrieved with non-fully qualified name. "
-          << "This behavior is deprecated in msgs12" << std::endl;
-    }
-  }
   return ret;
 }
 

--- a/test/integration/Factory_TEST.cc
+++ b/test/integration/Factory_TEST.cc
@@ -100,7 +100,7 @@ TEST(FactoryTest, NewWithMalformedData)
 TEST(FactoryTest, DeprecatedNonFullyQualified)
 {
   auto msg = Factory::New("StringMsg");
-  EXPECT_TRUE(msg.get() != nullptr);
+  EXPECT_TRUE(msg.get() == nullptr);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Reverting #512 in conjunction with a fix to https://github.com/gazebosim/gz-transport/issues/435.

## Summary

Support for non-qualified message names was removed in #476, but was reverting when during the Jetty version bumps in #512 due to https://github.com/gazebosim/gz-transport/issues/435. This reverts commit 08c8340c740eff8be8c51885f72a231622cda2f6 (#512) to accompany a fix in gz-transport.

## Test it

Forthcoming...

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
