### PR TITLE
Use `uint64` type for component IDs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -11,6 +11,11 @@ release will remove the deprecated code.
    package.xml package name. Use `find_package(gz-msgs)` instead of
    `find_package(gz-msgsX)` going forward.
 
+### Modifications
+
+1. **serialized_map.proto**
+  + In the `components` field of `SerializedEntityMap`, the key of the map has been changed from `int64` to `uint64`.
+
 ### Deprecations
 
 1. **camerasensor.proto**

--- a/proto/gz/msgs/serialized_map.proto
+++ b/proto/gz/msgs/serialized_map.proto
@@ -32,7 +32,7 @@ message SerializedEntityMap
   uint64 id = 1;
 
   /// \brief All the components belonging to the entity.
-  map<int64, SerializedComponent> components = 2;
+  map<uint64, SerializedComponent> components = 2;
 
   /// \brief Whether the entity and all its components should be removed at the
   /// current state.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The type used in gz-sim for component IDs is `uint64_t` which should match the type used here.

I believe this explains the test failures such as https://build.osrfoundation.org/job/gz_sim-ci-pr_any-homebrew-amd64/1992/testReport/

This breaks wire compatibility with previous versions of this message, so it should not be backported. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.