### PR TITLE
Fix issue in install tutorial

### DIFF
--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -179,7 +179,7 @@ This assumes you have created and activated a Conda environment while installing
 # Documentation
 
 API documentation and tutorials can be accessed at
-[https://gazebosim.org/libs/cmake](https://gazebosim.org/libs/cmake)
+[https://gazebosim.org/libs/msgs](https://gazebosim.org/libs/msgs)
 
 You can also generate the documentation from a clone of this repository by following these steps.
 
@@ -190,12 +190,12 @@ You can also generate the documentation from a clone of this repository by follo
 
 2. Clone the repository
   ```
-  git clone https://github.com/gazebosim/gz-cmake
+  git clone https://github.com/gazebosim/gz-msgs
   ```
 
 3. Configure and build the documentation.
   ```
-  cd gz-cmake
+  cd gz-msgs
   mkdir build
   cd build
   cmake ..


### PR DESCRIPTION
Tutorial was based on gz-cmake for documentation. Use gz-msgs instead. (Issue https://github.com/gazebosim/gazebo_test_cases/issues/2001)

<!-- For maintainers only -->

# 🎈 Release

Preparation for <X.Y.Z> release.

Comparison to <x.y.z>: https://github.com/gazebosim/<REPO>/compare/<LATEST_TAG_BRANCH>...<RELEASE_BRANCH>

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
