### PR TITLE
Add subscriber node UUID and snapshot metadata to the Discovery message

### DIFF
--- a/proto/gz/msgs/discovery.proto
+++ b/proto/gz/msgs/discovery.proto
@@ -82,6 +82,20 @@ message Discovery
     string n_uuid = 2;
   }
 
+  /// \brief Metadata describing a burst of SUBSCRIBERS_REP messages sent by
+  /// one process in response to a SUBSCRIBERS_REQ. The receiver knows that
+  /// the snapshot is complete when count messages have been received.
+  message SubscribersSnapshot
+  {
+    /// \brief Number of SUBSCRIBERS_REP messages in this burst. Zero when
+    /// the process has no subscriptions.
+    uint32 count = 1;
+
+    /// \brief Subscription generation of the process when the snapshot was
+    /// taken. Monotonically increasing on every subscription change.
+    uint64 generation = 2;
+  }
+
   /// \brief Information about a publisher.
   message Publisher
   {
@@ -181,4 +195,7 @@ message Discovery
     /// \brief Publisher information.
     Publisher pub     = 7;
   }
+
+  /// \brief Snapshot metadata attached to SUBSCRIBERS_REP messages.
+  SubscribersSnapshot subscribers_snapshot = 8;
 }

--- a/proto/gz/msgs/discovery.proto
+++ b/proto/gz/msgs/discovery.proto
@@ -77,6 +77,9 @@ message Discovery
   message Subscriber
   {
     string topic = 1;
+
+    /// \brief Node UUID of the subscriber.
+    string n_uuid = 2;
   }
 
   /// \brief Information about a publisher.


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-transport#914

## Summary

This patch adds two extra fields to the `Discovery` message, used by the gz-transport subscriber discovery updates:

* `Subscriber.n_uuid`: node UUID of a subscriber, so that a subscription can be announced and tracked per node.
* `Discovery.SubscribersSnapshot` (`count`, `generation`): metadata attached to each `SUBSCRIBERS_REP`, letting the receiver know when the reply burst of a process is complete and which subscription generation it represents.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.